### PR TITLE
fix(print): add video traceability markers

### DIFF
--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -742,11 +742,20 @@ footer { margin-top: 4.5rem; font-size: 0.85rem; opacity: 0.65; text-align: cent
     text-align: center;
     border: 1px dashed #666;
     padding: 1rem;
-    margin: 1.5rem 0;
+    margin: 1.5rem 0.2in;
     font-family: "Courier New", Courier, monospace;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     color: #333;
     page-break-inside: avoid;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .content-block blockquote,
+  .content-block .wp-block-quote,
+  .content-block [style*="border-left"] {
+    margin-left: 0.18in !important;
+    padding-left: 0.18in !important;
   }
 
   /* ── Mostrar só pt-BR na impressão ── */

--- a/pipeline/13-ssg/static/js/main.js
+++ b/pipeline/13-ssg/static/js/main.js
@@ -567,10 +567,37 @@ function toggleLabz() {
   // --- SPRINT 7: Print Markers ---
   function initPrintVideoMarkers() {
       document.querySelectorAll('iframe[src*="youtube"], iframe[src*="youtu.be"]').forEach(iframe => {
-          let marker = document.createElement('div');
+          if (iframe.previousElementSibling && iframe.previousElementSibling.classList.contains('print-video-marker')) {
+              return;
+          }
+
+          const marker = document.createElement('div');
           marker.className = 'print-video-marker';
-          marker.innerHTML = '🎥 [Um vídeo foi incorporado nesta seção]';
-          iframe.parentNode.insertBefore(marker, iframe);
+
+          const header = document.createElement('strong');
+          header.textContent = 'Video omitted in print / Vídeo omitido na impressão';
+          marker.appendChild(header);
+          marker.appendChild(document.createElement('br'));
+
+          const source = document.createElement('strong');
+          source.textContent = 'Source/Fonte: ';
+          marker.appendChild(source);
+          marker.appendChild(document.createTextNode('YouTube'));
+          marker.appendChild(document.createElement('br'));
+
+          const title = document.createElement('strong');
+          title.textContent = 'Title/Título: ';
+          marker.appendChild(title);
+          marker.appendChild(document.createTextNode(iframe.title || 'Embedded YouTube video'));
+          marker.appendChild(document.createElement('br'));
+
+          const url = document.createElement('strong');
+          url.textContent = 'URL: ';
+          marker.appendChild(url);
+          marker.appendChild(document.createTextNode(iframe.src));
+
+          const printHiddenContainer = iframe.closest('.video-container, .youtube-wrapper') || iframe;
+          printHiddenContainer.parentNode.insertBefore(marker, printHiddenContainer);
       });
   }
 

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -742,11 +742,20 @@ footer { margin-top: 4.5rem; font-size: 0.85rem; opacity: 0.65; text-align: cent
     text-align: center;
     border: 1px dashed #666;
     padding: 1rem;
-    margin: 1.5rem 0;
+    margin: 1.5rem 0.2in;
     font-family: "Courier New", Courier, monospace;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     color: #333;
     page-break-inside: avoid;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .content-block blockquote,
+  .content-block .wp-block-quote,
+  .content-block [style*="border-left"] {
+    margin-left: 0.18in !important;
+    padding-left: 0.18in !important;
   }
 
   /* ── Mostrar só pt-BR na impressão ── */

--- a/pipeline/13-static-site/js/main.js
+++ b/pipeline/13-static-site/js/main.js
@@ -567,10 +567,37 @@ function toggleLabz() {
   // --- SPRINT 7: Print Markers ---
   function initPrintVideoMarkers() {
       document.querySelectorAll('iframe[src*="youtube"], iframe[src*="youtu.be"]').forEach(iframe => {
-          let marker = document.createElement('div');
+          if (iframe.previousElementSibling && iframe.previousElementSibling.classList.contains('print-video-marker')) {
+              return;
+          }
+
+          const marker = document.createElement('div');
           marker.className = 'print-video-marker';
-          marker.innerHTML = '🎥 [Um vídeo foi incorporado nesta seção]';
-          iframe.parentNode.insertBefore(marker, iframe);
+
+          const header = document.createElement('strong');
+          header.textContent = 'Video omitted in print / Vídeo omitido na impressão';
+          marker.appendChild(header);
+          marker.appendChild(document.createElement('br'));
+
+          const source = document.createElement('strong');
+          source.textContent = 'Source/Fonte: ';
+          marker.appendChild(source);
+          marker.appendChild(document.createTextNode('YouTube'));
+          marker.appendChild(document.createElement('br'));
+
+          const title = document.createElement('strong');
+          title.textContent = 'Title/Título: ';
+          marker.appendChild(title);
+          marker.appendChild(document.createTextNode(iframe.title || 'Embedded YouTube video'));
+          marker.appendChild(document.createElement('br'));
+
+          const url = document.createElement('strong');
+          url.textContent = 'URL: ';
+          marker.appendChild(url);
+          marker.appendChild(document.createTextNode(iframe.src));
+
+          const printHiddenContainer = iframe.closest('.video-container, .youtube-wrapper') || iframe;
+          printHiddenContainer.parentNode.insertBefore(marker, printHiddenContainer);
       });
   }
 


### PR DESCRIPTION
Adds print-only traceability boxes for embedded YouTube videos so review PDFs preserve the video source context when iframes are hidden during printing.

Scope:
- CSS print marker styling
- JS marker generation from embedded YouTube iframes
- mirrored generated static-site assets

No canonical CSL/content changes.
No translation/content edits.
No global link/color normalization.