### PR TITLE
fix(print): preserve audio term styling in PDFs

### DIFF
--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -1322,3 +1322,14 @@ body[data-theme="stardust"] .csl-tattoo td {
   }
 }
 
+
+/* [PRINT REVIEW V1] Preserve audio-term distinction in printed/PDF review copies.
+   Glossary terms remain orange+dotted; audio terms remain red+dashed. */
+@media print {
+  .term-highlight.has-audio {
+    color: #c0392b !important;
+    font-style: italic;
+    font-weight: bold;
+    border-bottom: 1.5pt dashed #c0392b !important;
+  }
+}

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -1322,3 +1322,14 @@ body[data-theme="stardust"] .csl-tattoo td {
   }
 }
 
+
+/* [PRINT REVIEW V1] Preserve audio-term distinction in printed/PDF review copies.
+   Glossary terms remain orange+dotted; audio terms remain red+dashed. */
+@media print {
+  .term-highlight.has-audio {
+    color: #c0392b !important;
+    font-style: italic;
+    font-weight: bold;
+    border-bottom: 1.5pt dashed #c0392b !important;
+  }
+}


### PR DESCRIPTION
Preserves the visual distinction between protected glossary terms and audio-linked terms in printed/PDF review copies.

Scope:

- Keeps glossary/protected terms orange with dotted underline
- Keeps audio-linked terms red with dashed underline
- Matches the on-screen cognitive distinction used by reviewers
- CSS-only print patch

No canonical CSL/content changes.
No translation/content edits.
No JavaScript changes.