### PR TITLE
fix(print): format review legend colors

### DIFF
--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -1306,9 +1306,16 @@ body[data-theme="stardust"] .csl-tattoo td {
     font-family: "Courier New", Courier, monospace;
     font-size: 0.85rem;
     color: #333;
-    overflow-wrap: anywhere;
     box-sizing: border-box;
     max-width: calc(100% - 0.7rem);
+    hyphens: none;
+    word-break: normal;
+    overflow-wrap: normal;
+  }
+
+  .print-review-url {
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 }
 
@@ -1327,6 +1334,23 @@ body[data-theme="stardust"] .csl-tattoo td {
    Glossary terms remain orange+dotted; audio terms remain red+dashed. */
 @media print {
   .term-highlight.has-audio {
+    color: #c0392b !important;
+    font-style: italic;
+    font-weight: bold;
+    border-bottom: 1.5pt dashed #c0392b !important;
+  }
+}
+
+/* [PRINT REVIEW V1] Legend swatches for printed review banner only */
+@media print {
+  .print-legend-glossary {
+    color: #c47c00 !important;
+    font-style: italic;
+    font-weight: bold;
+    border-bottom: 1pt dotted #c47c00 !important;
+  }
+
+  .print-legend-audio {
     color: #c0392b !important;
     font-style: italic;
     font-weight: bold;

--- a/pipeline/13-ssg/static/js/main.js
+++ b/pipeline/13-ssg/static/js/main.js
@@ -618,27 +618,48 @@ function toggleLabz() {
       const banner = document.createElement('div');
       banner.className = 'print-review-banner';
 
-      const lines = [
-          ['strong', 'DRAFT / RASCUNHO'],
-          ['text', 'Translation review copy / Cópia para revisão de tradução'],
-          ['text', 'Source/Fonte: PureDhamma.net'],
-          ['text', 'AXIS-NIDDHI page URL / URL da página AXIS-NIDDHI: ' + window.location.href],
-          ['text', 'Canonical ID / ID canônico: ' + pdpn],
-          ['text', 'Note/Nota: This printed/PDF copy is for review and archival traceability. The doctrinal source remains PureDhamma.net.']
-      ];
+      const header = document.createElement('strong');
+      header.textContent = 'DRAFT / RASCUNHO';
+      banner.appendChild(header);
+      banner.appendChild(document.createElement('br'));
 
-      lines.forEach(function(item, index) {
-          if (item[0] === 'strong') {
-              const strong = document.createElement('strong');
-              strong.textContent = item[1];
-              banner.appendChild(strong);
-          } else {
-              banner.appendChild(document.createTextNode(item[1]));
-          }
-          if (index < lines.length - 1) {
-              banner.appendChild(document.createElement('br'));
-          }
-      });
+      banner.appendChild(document.createTextNode('Translation review copy / Cópia para revisão de tradução'));
+      banner.appendChild(document.createElement('br'));
+
+      banner.appendChild(document.createTextNode('Source/Fonte: PureDhamma.net'));
+      banner.appendChild(document.createElement('br'));
+
+      banner.appendChild(document.createTextNode('AXIS-NIDDHI page URL / URL da página AXIS-NIDDHI: '));
+      const urlSpan = document.createElement('span');
+      urlSpan.className = 'print-review-url';
+      urlSpan.textContent = window.location.href;
+      banner.appendChild(urlSpan);
+      banner.appendChild(document.createElement('br'));
+
+      banner.appendChild(document.createTextNode('Canonical ID / ID canônico: ' + pdpn));
+      banner.appendChild(document.createElement('br'));
+
+      banner.appendChild(document.createTextNode('Note/Nota: This printed/PDF copy is for review and archival traceability. The doctrinal source remains PureDhamma.net.'));
+      banner.appendChild(document.createElement('br'));
+      banner.appendChild(document.createElement('br'));
+
+      const legendHeader = document.createElement('strong');
+      legendHeader.textContent = 'COLOR LEGEND / LEGENDA DE CORES:';
+      banner.appendChild(legendHeader);
+      banner.appendChild(document.createElement('br'));
+
+      const legendGlossarySpan = document.createElement('span');
+      legendGlossarySpan.className = 'print-legend-glossary';
+      legendGlossarySpan.textContent = 'Orange/Laranja';
+      banner.appendChild(legendGlossarySpan);
+      banner.appendChild(document.createTextNode(' = Glossary term / Termo protegido do glossário'));
+      banner.appendChild(document.createElement('br'));
+
+      const legendAudioSpan = document.createElement('span');
+      legendAudioSpan.className = 'print-legend-audio';
+      legendAudioSpan.textContent = 'Red/Vermelho';
+      banner.appendChild(legendAudioSpan);
+      banner.appendChild(document.createTextNode(' = Glossary term with audio / Termo do glossário com áudio'));
 
       article.parentNode.insertBefore(banner, article);
   }

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -1306,9 +1306,16 @@ body[data-theme="stardust"] .csl-tattoo td {
     font-family: "Courier New", Courier, monospace;
     font-size: 0.85rem;
     color: #333;
-    overflow-wrap: anywhere;
     box-sizing: border-box;
     max-width: calc(100% - 0.7rem);
+    hyphens: none;
+    word-break: normal;
+    overflow-wrap: normal;
+  }
+
+  .print-review-url {
+    overflow-wrap: anywhere;
+    word-break: break-word;
   }
 }
 
@@ -1327,6 +1334,23 @@ body[data-theme="stardust"] .csl-tattoo td {
    Glossary terms remain orange+dotted; audio terms remain red+dashed. */
 @media print {
   .term-highlight.has-audio {
+    color: #c0392b !important;
+    font-style: italic;
+    font-weight: bold;
+    border-bottom: 1.5pt dashed #c0392b !important;
+  }
+}
+
+/* [PRINT REVIEW V1] Legend swatches for printed review banner only */
+@media print {
+  .print-legend-glossary {
+    color: #c47c00 !important;
+    font-style: italic;
+    font-weight: bold;
+    border-bottom: 1pt dotted #c47c00 !important;
+  }
+
+  .print-legend-audio {
     color: #c0392b !important;
     font-style: italic;
     font-weight: bold;

--- a/pipeline/13-static-site/js/main.js
+++ b/pipeline/13-static-site/js/main.js
@@ -618,27 +618,48 @@ function toggleLabz() {
       const banner = document.createElement('div');
       banner.className = 'print-review-banner';
 
-      const lines = [
-          ['strong', 'DRAFT / RASCUNHO'],
-          ['text', 'Translation review copy / Cópia para revisão de tradução'],
-          ['text', 'Source/Fonte: PureDhamma.net'],
-          ['text', 'AXIS-NIDDHI page URL / URL da página AXIS-NIDDHI: ' + window.location.href],
-          ['text', 'Canonical ID / ID canônico: ' + pdpn],
-          ['text', 'Note/Nota: This printed/PDF copy is for review and archival traceability. The doctrinal source remains PureDhamma.net.']
-      ];
+      const header = document.createElement('strong');
+      header.textContent = 'DRAFT / RASCUNHO';
+      banner.appendChild(header);
+      banner.appendChild(document.createElement('br'));
 
-      lines.forEach(function(item, index) {
-          if (item[0] === 'strong') {
-              const strong = document.createElement('strong');
-              strong.textContent = item[1];
-              banner.appendChild(strong);
-          } else {
-              banner.appendChild(document.createTextNode(item[1]));
-          }
-          if (index < lines.length - 1) {
-              banner.appendChild(document.createElement('br'));
-          }
-      });
+      banner.appendChild(document.createTextNode('Translation review copy / Cópia para revisão de tradução'));
+      banner.appendChild(document.createElement('br'));
+
+      banner.appendChild(document.createTextNode('Source/Fonte: PureDhamma.net'));
+      banner.appendChild(document.createElement('br'));
+
+      banner.appendChild(document.createTextNode('AXIS-NIDDHI page URL / URL da página AXIS-NIDDHI: '));
+      const urlSpan = document.createElement('span');
+      urlSpan.className = 'print-review-url';
+      urlSpan.textContent = window.location.href;
+      banner.appendChild(urlSpan);
+      banner.appendChild(document.createElement('br'));
+
+      banner.appendChild(document.createTextNode('Canonical ID / ID canônico: ' + pdpn));
+      banner.appendChild(document.createElement('br'));
+
+      banner.appendChild(document.createTextNode('Note/Nota: This printed/PDF copy is for review and archival traceability. The doctrinal source remains PureDhamma.net.'));
+      banner.appendChild(document.createElement('br'));
+      banner.appendChild(document.createElement('br'));
+
+      const legendHeader = document.createElement('strong');
+      legendHeader.textContent = 'COLOR LEGEND / LEGENDA DE CORES:';
+      banner.appendChild(legendHeader);
+      banner.appendChild(document.createElement('br'));
+
+      const legendGlossarySpan = document.createElement('span');
+      legendGlossarySpan.className = 'print-legend-glossary';
+      legendGlossarySpan.textContent = 'Orange/Laranja';
+      banner.appendChild(legendGlossarySpan);
+      banner.appendChild(document.createTextNode(' = Glossary term / Termo protegido do glossário'));
+      banner.appendChild(document.createElement('br'));
+
+      const legendAudioSpan = document.createElement('span');
+      legendAudioSpan.className = 'print-legend-audio';
+      legendAudioSpan.textContent = 'Red/Vermelho';
+      banner.appendChild(legendAudioSpan);
+      banner.appendChild(document.createTextNode(' = Glossary term with audio / Termo do glossário com áudio'));
 
       article.parentNode.insertBefore(banner, article);
   }


### PR DESCRIPTION
Improves the print/PDF review banner so printed translation review copies remain self-explanatory.

Scope:

- Keeps the DRAFT / RASCUNHO traceability banner print-only
- Prevents awkward hyphenation inside the technical review box
- Adds bilingual color legend for reviewer cognition
- Formats legend samples to match actual print semantics:
  - Orange/dotted = glossary protected term
  - Red/dashed = glossary term with audio
- Keeps screen layout unchanged
- CSS/JS-only print review patch

No canonical CSL/content changes.
No translation/content edits.
No doctrinal color normalization.
No print seal footer retained.