### PR TITLE
Docs/torre de gits guardrails 20260426

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+# AGENTS.md — AXIS-NIDDHI Local Agent Guardrails
+
+## Mandatory preflight
+
+Before editing any file, every local coding agent must report:
+
+```bash
+pwd
+git branch --show-current
+git status --branch --short
+git remote -v
+```
+
+If the workspace role is unclear, stop and ask.
+
+## Workspace roles
+
+| Path | Role | Rule |
+|---|---|---|
+| `/home/sanghop/axis/axis-niddhi-production` | production | clean production branches only |
+| `/home/sanghop/bengyond-playground` | rescue quarantine | read/diff/cherry-pick archaeology only; no push |
+| `/home/sanghop/axis/axis-niddhi-lab` | integration lab | controlled integration |
+| `/home/sanghop/axis/axis-navigator-lab` | Navigator lab | UX experiments |
+| `/home/sanghop/axis/axis-nana-lab` | NANA lab | retrieval/LLM/provider experiments |
+| `/home/sanghop/axis/axis-print-review` | print review lab | print/PDF/CSS work |
+
+## Absolute rules
+
+- Do not use `git add .`.
+- Do not push from rescue or playground clones.
+- Do not commit secrets.
+- Do not run `build.py` unless explicitly requested.
+- Do not run pipeline stages unless explicitly requested.
+- Do not modify generated static output unless explicitly approved.
+- Do not treat `pipeline/13-static-site/` as source truth.
+- The CSL/canon is upstream of publication artifacts.
+
+## High-risk paths
+
+Do not stage these accidentally:
+
+```text
+pipeline/13-static-site/
+pipeline/13-static-site/pages/
+pipeline/13-static-site/assets/
+pipeline/13-ssg/cache/
+outputs/
+outputs/nana/
+review/
+```
+
+Any commit touching generated static output requires the exact approval sentence:
+
+```text
+sim, queremos publicar exatamente este build
+```
+
+## Secret policy
+
+Never print, stage, commit, or publish secret contents.
+
+High-risk examples:
+
+```text
+pipeline/scripts/private/
+.env
+deepl_key.txt
+github_token.txt
+wp_password.txt
+*.pem
+*.key
+credentials
+tokens
+```
+
+Secret-like paths may be reported by filename/path only.
+
+## Production policy
+
+Production branches must be small, reviewable, and intentional.
+
+Allowed production change types:
+
+```text
+docs-only
+hotfix-css
+hotfix-js
+template-hotfix
+metadata-review
+```
+
+Generated mass output is forbidden unless explicitly approved.
+
+## Rescue policy
+
+The rescue workspace is archaeology.
+
+Allowed:
+
+```text
+inspect
+grep
+diff
+manual extraction of ideas
+cherry-pick only after human architectural approval
+```
+
+Forbidden:
+
+```text
+push
+deploy
+clean
+reset
+mass commit
+production build
+```

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,36 +1,69 @@
-# GEMINI.md — AXIS-NIDDHI Production Rules
+# GEMINI.md — AXIS-NIDDHI Gemini Code Assist Guardrails
+
+## Role
+
+Gemini Code Assist may inspect, reason, and propose changes, but must obey the local workspace role before editing.
+
+## Mandatory preflight
+
+Before any edit, report:
+
+```bash
+pwd
+git branch --show-current
+git status --branch --short
+git remote -v
+```
+
+If the workspace is `/home/sanghop/bengyond-playground`, treat it as rescue quarantine.
+
+## Do not do automatically
+
+- Do not run `build.py`.
+- Do not run pipeline stages.
+- Do not push.
+- Do not use `git add .`.
+- Do not clean, reset, stash, merge, pull, or rebase unless explicitly requested.
+- Do not stage generated static output.
+- Do not print secret contents.
+
+## Generated output warning
+
+These paths are high-risk:
+
+```text
+pipeline/13-static-site/
+pipeline/13-static-site/pages/
+pipeline/13-static-site/assets/
+pipeline/13-ssg/cache/
+outputs/
+outputs/nana/
+review/
+```
+
+Do not stage them unless the human explicitly says:
+
+```text
+sim, queremos publicar exatamente este build
+```
+
+## Architectural rule
+
+AXIS-NIDDHI is a deterministic corpus preservation engine.
+
+The static site is a derived publication artifact.
+
+The CSL/canon is the source of truth.
+
+Navigator, NANA, Academy, Cosmos, and future UX/LLM layers are downstream consumers and must not mutate canonical content.
+
+## Existing production notes
 
 This repository is production-sensitive.
 
-## Absolute rules
-
-- Never run `git add .`.
-- Never run `git reset`.
-- Never run `git clean`.
-- Never run `git stash`.
-- Never push without explicit human approval.
 - Never commit credentials or files under `scripts/private/`.
 - Never edit Canon/CSL for UI tasks.
 - Never change `build.py` unless explicitly requested.
 - Never shorten URLs used for archival traceability.
 - Preserve didactic colors from PureDhamma content.
-
-## Architecture
-
-CSL/Canon is the source of truth.
-Static site is derived publication.
-Print CSS and review labels belong only to publication/UX layer.
-
-## Safe workflow
-
-Before editing, always show:
-
-git branch --show-current
-git status --short
-git diff --stat
-
-After editing, always show:
-
-git diff --stat
-git diff --name-only
-git status --short
+- Print CSS and review labels belong only to the publication/UX layer.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -61,7 +61,7 @@ Navigator, NANA, Academy, Cosmos, and future UX/LLM layers are downstream consum
 
 This repository is production-sensitive.
 
-- Never commit credentials or files under `scripts/private/`.
+- Never commit credentials or files under `pipeline/scripts/private/` or any `scripts/private/` subtree.
 - Never edit Canon/CSL for UI tasks.
 - Never change `build.py` unless explicitly requested.
 - Never shorten URLs used for archival traceability.

--- a/docs/TORRE_DE_GITS_GUARDRAILS_20260426.md
+++ b/docs/TORRE_DE_GITS_GUARDRAILS_20260426.md
@@ -1,0 +1,181 @@
+# Torre de Gits — Workspace Guardrails
+
+**Date:** 2026-04-26  
+**Status:** Active operational rule  
+**Scope:** AXIS-NIDDHI production, rescue, lab, Navigator, NANA, print review
+
+---
+
+## 1. Purpose
+
+This document records the official local workspace strategy for AXIS-NIDDHI after the Torre de Gits consolidation.
+
+The project has a public production repository and live deployment surfaces. The Cloudflare deployment is connected to the GitHub repository `matikamata/axis-niddhi`, and the GitHub Pages archive is also public.
+
+Therefore, local workspaces must be separated by operational role.
+
+The goal is to prevent accidental deployment of experimental work, generated static output, local review artifacts, secrets, or large unreviewed diffs.
+
+---
+
+## 2. Official workspace roles
+
+| Path | Role | Rule |
+|---|---|---|
+| `/home/sanghop/axis/axis-niddhi-production` | Production clone | Clean reference, main branch, Cloudflare-connected repo |
+| `/home/sanghop/bengyond-playground` | Rescue quarantine | Read/diff/cherry-pick only; no push |
+| `/home/sanghop/axis/axis-niddhi-lab` | Future integration lab | Controlled integration before production |
+| `/home/sanghop/axis/axis-navigator-lab` | Navigator UX lab | UX experiments only |
+| `/home/sanghop/axis/axis-nana-lab` | NANA/LLM lab | Retrieval, source-bound Q&A, provider experiments |
+| `/home/sanghop/axis/axis-print-review` | Print review lab | CSS/print/PDF work before production |
+
+---
+
+## 3. Production rules
+
+The production clone is the only local workspace allowed to prepare production branches for `matikamata/axis-niddhi`.
+
+Hard rules:
+
+- Do not run experimental builds in production.
+- Do not run NANA experiments in production.
+- Do not run Navigator experiments in production.
+- Do not use `git add .`.
+- Do not commit generated mass output without explicit human approval.
+- Do not commit secrets.
+- Do not push directly from rescue or playground clones.
+- Do not use dirty worktrees for production commits.
+
+---
+
+## 4. Rescue quarantine rules
+
+The rescue workspace exists only for archaeology and selective recovery.
+
+Allowed:
+
+- inspect
+- diff
+- grep
+- copy specific ideas manually
+- cherry-pick only after human architectural approval
+
+Forbidden:
+
+- push
+- deploy
+- clean
+- reset
+- mass commit
+- run production build
+- treat as current production truth
+
+The rescue clone push URL must remain disabled.
+
+Expected local config:
+
+```bash
+git remote -v
+git config --local --get push.default
+git config --local --get axis.role
+git config --local --get axis.deploy
+```
+
+Expected values:
+
+```text
+origin push: DISABLED_RESCUE_QUARANTINE_DO_NOT_PUSH
+push.default: nothing
+axis.role: rescue-quarantine
+axis.deploy: forbidden
+```
+
+---
+
+## 5. Generated output policy
+
+The following paths are high risk:
+
+```text
+pipeline/13-static-site/
+pipeline/13-static-site/pages/
+pipeline/13-static-site/assets/
+pipeline/13-ssg/cache/
+outputs/
+outputs/nana/
+review/
+```
+
+These paths may contain generated or review artifacts.
+
+They must not be committed accidentally.
+
+Any commit touching generated static output requires an explicit approval sentence from the human operator:
+
+```text
+sim, queremos publicar exatamente este build
+```
+
+Without that sentence, generated output must not be staged.
+
+---
+
+## 6. Secret policy
+
+Never commit or publish:
+
+```text
+pipeline/scripts/private/
+.env
+deepl_key.txt
+github_token.txt
+wp_password.txt
+*.pem
+*.key
+credentials
+tokens
+```
+
+Secret-like filenames may be reported by path only. Contents must not be printed.
+
+---
+
+## 7. Agent policy
+
+CodeX, Gemini Code Assist, Claude Code, or any other local coding assistant must obey the workspace role before editing.
+
+Before any edit, the agent must report:
+
+```bash
+pwd
+git branch --show-current
+git status --branch --short
+git remote -v
+```
+
+If the workspace role is unclear, the agent must stop and ask.
+
+---
+
+## 8. Canonical decision
+
+The old castle is preserved as archaeology.
+
+The new castle is built through separated workspaces:
+
+```text
+production
+lab
+navigator
+nana
+print-review
+rescue
+```
+
+Production remains clean.
+
+Labs may experiment.
+
+Rescue preserves memory.
+
+Only reviewed, minimal, intentional changes cross into production.


### PR DESCRIPTION
## Summary

This PR adds docs-only operational guardrails for the Torre de Gits consolidation.

It documents:

- production vs rescue vs lab workspace roles
- rescue quarantine policy
- generated output risk
- secret handling policy
- local agent preflight rules for CodeX/Gemini/Claude-style agents
- the rule that CSL/canon remains upstream of publication artifacts

## Safety

Docs-only change.

Changed files:

- AGENTS.md
- GEMINI.md
- docs/TORRE_DE_GITS_GUARDRAILS_20260426.md

No pipeline files touched.
No generated static output touched.
No build scripts run.
No production main push.

## Merge note

Do not merge until human review confirms this docs-only PR.