### PR TITLE
feat: add NANA static artifact copy hook

### DIFF
--- a/docs/AXIS_NIDDHI_NANA_STATIC_COPY_HOOK_2026-04-26.md
+++ b/docs/AXIS_NIDDHI_NANA_STATIC_COPY_HOOK_2026-04-26.md
@@ -1,0 +1,18 @@
+# AXIS NIDDHI NANA Static Copy Hook
+Date: 2026-04-26
+
+## Overview
+This document outlines the behavior of the NANA static artifact copy hook introduced in `build.py` (Wave 2c.4c). This hook is responsible for bridging NANA outputs into the static site payload.
+
+## Paths
+- **Source:** `pipeline/capsule/nana/`
+- **Target:** `pipeline/13-static-site/assets/nana/`
+
+## Rules and Safety Guarantees
+- **JSON-only:** Only `.json` files are copied.
+- **Fail-closed guard:** Files containing forbidden markers (such as `GOOGLE_APPLICATION_CREDENTIALS`, secret keys, or absolute `/home/` paths) are blocked and rejected.
+- **No provider execution:** This step merely copies static JSON. It does not execute LLM models or run NANA core logic.
+- **No API calls:** No external networks are contacted.
+- **No browser credentials:** The frontend receives pure data; no credentials are leaked or injected.
+- **Graceful no-op:** If the `pipeline/capsule/nana/` directory does not exist or has no JSON artifacts, the build logs it and continues safely without breaking the site.
+- **No Navigator integration:** In this wave, we only place the artifacts in the target static directory. The frontend UI (Navigator) is not updated to fetch or display them yet.

--- a/pipeline/13-ssg/build.py
+++ b/pipeline/13-ssg/build.py
@@ -219,6 +219,93 @@ def _copy_static_assets() -> None:
     logger.info(f"📦 Static assets copiados → {OUTPUT_DIR}")
 
 
+def _copy_nana_static_artifacts() -> None:
+    """
+    Copia os artefatos estáticos JSON do NANA para o output do SSG.
+    Fail-closed guard para rejeitar segredos.
+    Não executa LLM, não faz chamadas API.
+    """
+    source_dir = PIPELINE_ROOT / "capsule" / "nana"
+    target_dir = OUTPUT_DIR / "assets" / "nana"
+
+    if not source_dir.exists():
+        logger.info("📦 NANA capsule not found; skipping static NANA artifacts.")
+        return
+
+    json_files = list(source_dir.rglob("*.json"))
+    if not json_files:
+        logger.info("📦 NANA capsule found but no JSON artifacts present.")
+        return
+
+    forbidden_markers = [
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "gen-lang-client",
+        "private_key",
+        "BEGIN PRIVATE KEY",
+        "api_key",
+        "access_token",
+        "refresh_token",
+        "github_token",
+        "deepl_key",
+        "wp_password",
+        "/home/",
+        "/media/",
+        "pipeline/scripts/private"
+    ]
+    
+    ignore_names = {"readme.md", ".gitkeep"}
+    ignore_dirs = {"__pycache__", "private", ".git"}
+    
+    copied = 0
+    blocked = 0
+
+    for f in json_files:
+        if f.is_dir() or f.name.startswith("."):
+            continue
+            
+        if f.suffix.lower() != ".json":
+            continue
+            
+        if f.name.lower() in ignore_names:
+            continue
+            
+        if any(part in ignore_dirs or part.startswith(".") for part in f.parts):
+            continue
+            
+        try:
+            content = f.read_text(encoding="utf-8")
+        except Exception as e:
+            logger.warning(f"⚠️  Falha ao ler artefato NANA {f.name}: {e}")
+            continue
+            
+        path_str = str(f)
+        has_forbidden = False
+        for marker in forbidden_markers:
+            if marker in path_str or marker in content:
+                logger.warning(f"🚨 blocked NANA artifact due forbidden marker '{marker}': {f.name}")
+                has_forbidden = True
+                blocked += 1
+                break
+                
+        if has_forbidden:
+            continue
+            
+        rel_path = f.relative_to(source_dir)
+        target_file = target_dir / rel_path
+        target_file.parent.mkdir(parents=True, exist_ok=True)
+        
+        try:
+            target_file.write_text(content, encoding="utf-8")
+            copied += 1
+        except Exception as e:
+            logger.warning(f"⚠️  Falha ao escrever artefato NANA {rel_path}: {e}")
+            
+    if copied > 0 or blocked > 0:
+        logger.info(f"🧠 copied {copied} NANA static artifact(s).")
+        if blocked > 0:
+            logger.warning(f"🚨 {blocked} blocked due to forbidden markers.")
+
+
 def _ensure_github_pages_markers() -> None:
     """Garantias mínimas para deploy estático em GitHub Pages backup."""
     marker = OUTPUT_DIR / ".nojekyll"
@@ -822,6 +909,7 @@ def main() -> None:
     # ── 7. ASSETS + SEARCH INDEX + AUDIO PIPELINE ────────────────────────────
     logger.info("▶ Fase 7/8: Copiando assets estáticos e áudio...")
     _copy_static_assets()
+    _copy_nana_static_artifacts()
     _ensure_github_pages_markers()
     _generate_search_index(posts)
     external_audio = _copy_audio_files(CSL_DIR)

--- a/pipeline/13-ssg/build.py
+++ b/pipeline/13-ssg/build.py
@@ -269,19 +269,22 @@ def _copy_nana_static_artifacts() -> None:
         if f.name.lower() in ignore_names:
             continue
             
-        if any(part in ignore_dirs or part.startswith(".") for part in f.parts):
+        rel_path = f.relative_to(source_dir)
+            
+        if any(part in ignore_dirs or part.startswith(".") for part in rel_path.parts):
             continue
             
         try:
-            content = f.read_text(encoding="utf-8")
+            raw = f.read_bytes()
+            content = raw.decode("utf-8")
         except Exception as e:
             logger.warning(f"⚠️  Falha ao ler artefato NANA {f.name}: {e}")
             continue
             
-        path_str = str(f)
+        rel_path_str = rel_path.as_posix()
         has_forbidden = False
         for marker in forbidden_markers:
-            if marker in path_str or marker in content:
+            if marker in rel_path_str or marker in content:
                 logger.warning(f"🚨 blocked NANA artifact due forbidden marker '{marker}': {f.name}")
                 has_forbidden = True
                 blocked += 1
@@ -290,12 +293,11 @@ def _copy_nana_static_artifacts() -> None:
         if has_forbidden:
             continue
             
-        rel_path = f.relative_to(source_dir)
         target_file = target_dir / rel_path
         target_file.parent.mkdir(parents=True, exist_ok=True)
         
         try:
-            target_file.write_text(content, encoding="utf-8")
+            target_file.write_bytes(raw)
             copied += 1
         except Exception as e:
             logger.warning(f"⚠️  Falha ao escrever artefato NANA {rel_path}: {e}")

--- a/pipeline/13-ssg/build.py
+++ b/pipeline/13-ssg/build.py
@@ -228,6 +228,9 @@ def _copy_nana_static_artifacts() -> None:
     source_dir = PIPELINE_ROOT / "capsule" / "nana"
     target_dir = OUTPUT_DIR / "assets" / "nana"
 
+    if target_dir.exists():
+        shutil.rmtree(target_dir, ignore_errors=True)
+
     if not source_dir.exists():
         logger.info("📦 NANA capsule not found; skipping static NANA artifacts.")
         return
@@ -277,8 +280,10 @@ def _copy_nana_static_artifacts() -> None:
         try:
             raw = f.read_bytes()
             content = raw.decode("utf-8")
+            json.loads(content)
         except Exception as e:
-            logger.warning(f"⚠️  Falha ao ler artefato NANA {f.name}: {e}")
+            logger.warning(f"⚠️  Falha ao ler ou parsear JSON NANA {f.name}: {e}")
+            blocked += 1
             continue
             
         rel_path_str = rel_path.as_posix()


### PR DESCRIPTION
- Wave 2c.4c
- NIDDHI static copy hook only
- source: pipeline/capsule/nana/
- target: pipeline/13-static-site/assets/nana/
- JSON-only copy
- fail-closed forbidden marker guard
- no NANA/provider execution
- no API calls
- no build run
- no Navigator integration
- no production touched
- no rescue touched