### PR TITLE
fix(print): rebalance batch 01 print review UX

### DIFF
--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -1362,29 +1362,7 @@ body[data-theme="stardust"] .csl-tattoo td {
   }
 }
 
-/* [FLAGFIX-016] Center printable reading column.
-   Prevents A4/PDF text from visually leaning toward one side after print reset. */
-@media print {
-  main {
-    width: 17.2cm !important;
-    max-width: 100% !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    box-sizing: border-box !important;
-  }
-
-  .content-block,
-  .post-header,
-  .print-review-banner,
-  .print-video-marker {
-    box-sizing: border-box !important;
-  }
-}
-
-/* [FLAGFIX-016 v2] Print layout rebalance:
-   wider column, title higher, denser draft banner, better page economy. */
+/* [FLAGFIX-BATCH01] Print review A4 layout rebalance */
 @media print {
   main {
     width: 18.2cm !important;

--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -1300,22 +1300,26 @@ body[data-theme="stardust"] .csl-tattoo td {
 @media print {
   .print-review-banner {
     display: block !important;
-    border: 1pt solid #666;
-    padding: 1rem;
-    margin: 0.35rem 0.35rem 1.5rem 0.35rem;
-    font-family: "Courier New", Courier, monospace;
-    font-size: 0.85rem;
-    color: #333;
-    box-sizing: border-box;
-    max-width: calc(100% - 0.7rem);
-    hyphens: none;
-    word-break: normal;
-    overflow-wrap: normal;
+    border: 0.8pt solid #777 !important;
+    background: #f7f7f7 !important;
+    padding: 0.42rem 0.62rem !important;
+    margin: 0.15rem 0 0.85rem 0 !important;
+    width: auto !important;
+    max-width: none !important;
+    box-sizing: border-box !important;
+    font-family: "Courier Prime", "IBM Plex Mono", "JetBrains Mono", "Anonymous Pro", "Courier New", monospace !important;
+    font-size: 8.2pt !important;
+    line-height: 1.28 !important;
+    letter-spacing: 0.005em !important;
+    color: #555 !important;
+    hyphens: none !important;
+    word-break: normal !important;
+    overflow-wrap: normal !important;
   }
 
   .print-review-url {
-    overflow-wrap: anywhere;
-    word-break: break-word;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
   }
 }
 
@@ -1355,5 +1359,73 @@ body[data-theme="stardust"] .csl-tattoo td {
     font-style: italic;
     font-weight: bold;
     border-bottom: 1.5pt dashed #c0392b !important;
+  }
+}
+
+/* [FLAGFIX-016] Center printable reading column.
+   Prevents A4/PDF text from visually leaning toward one side after print reset. */
+@media print {
+  main {
+    width: 17.2cm !important;
+    max-width: 100% !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    box-sizing: border-box !important;
+  }
+
+  .content-block,
+  .post-header,
+  .print-review-banner,
+  .print-video-marker {
+    box-sizing: border-box !important;
+  }
+}
+
+/* [FLAGFIX-016 v2] Print layout rebalance:
+   wider column, title higher, denser draft banner, better page economy. */
+@media print {
+  main {
+    width: 18.2cm !important;
+    max-width: 100% !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    box-sizing: border-box !important;
+  }
+
+  .title-pt,
+  .title-en {
+    text-align: center !important;
+    margin-top: 0.2rem !important;
+    margin-bottom: 0.55rem !important;
+    line-height: 1.08 !important;
+  }
+
+  .post-header,
+  .content-block,
+  .print-review-banner,
+  .print-video-marker {
+    box-sizing: border-box !important;
+  }
+
+  .print-review-banner strong,
+  .print-review-banner b {
+    color: #333 !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.015em !important;
+  }
+
+  body {
+    font-size: 11pt !important;
+    line-height: 1.6 !important;
+  }
+
+  .content-block p,
+  .content-block li {
+    margin-top: 0.45rem !important;
+    margin-bottom: 0.45rem !important;
   }
 }

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -1362,29 +1362,7 @@ body[data-theme="stardust"] .csl-tattoo td {
   }
 }
 
-/* [FLAGFIX-016] Center printable reading column.
-   Prevents A4/PDF text from visually leaning toward one side after print reset. */
-@media print {
-  main {
-    width: 17.2cm !important;
-    max-width: 100% !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    box-sizing: border-box !important;
-  }
-
-  .content-block,
-  .post-header,
-  .print-review-banner,
-  .print-video-marker {
-    box-sizing: border-box !important;
-  }
-}
-
-/* [FLAGFIX-016 v2] Print layout rebalance:
-   wider column, title higher, denser draft banner, better page economy. */
+/* [FLAGFIX-BATCH01] Print review A4 layout rebalance */
 @media print {
   main {
     width: 18.2cm !important;

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -1300,22 +1300,26 @@ body[data-theme="stardust"] .csl-tattoo td {
 @media print {
   .print-review-banner {
     display: block !important;
-    border: 1pt solid #666;
-    padding: 1rem;
-    margin: 0.35rem 0.35rem 1.5rem 0.35rem;
-    font-family: "Courier New", Courier, monospace;
-    font-size: 0.85rem;
-    color: #333;
-    box-sizing: border-box;
-    max-width: calc(100% - 0.7rem);
-    hyphens: none;
-    word-break: normal;
-    overflow-wrap: normal;
+    border: 0.8pt solid #777 !important;
+    background: #f7f7f7 !important;
+    padding: 0.42rem 0.62rem !important;
+    margin: 0.15rem 0 0.85rem 0 !important;
+    width: auto !important;
+    max-width: none !important;
+    box-sizing: border-box !important;
+    font-family: "Courier Prime", "IBM Plex Mono", "JetBrains Mono", "Anonymous Pro", "Courier New", monospace !important;
+    font-size: 8.2pt !important;
+    line-height: 1.28 !important;
+    letter-spacing: 0.005em !important;
+    color: #555 !important;
+    hyphens: none !important;
+    word-break: normal !important;
+    overflow-wrap: normal !important;
   }
 
   .print-review-url {
-    overflow-wrap: anywhere;
-    word-break: break-word;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
   }
 }
 
@@ -1355,5 +1359,73 @@ body[data-theme="stardust"] .csl-tattoo td {
     font-style: italic;
     font-weight: bold;
     border-bottom: 1.5pt dashed #c0392b !important;
+  }
+}
+
+/* [FLAGFIX-016] Center printable reading column.
+   Prevents A4/PDF text from visually leaning toward one side after print reset. */
+@media print {
+  main {
+    width: 17.2cm !important;
+    max-width: 100% !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    box-sizing: border-box !important;
+  }
+
+  .content-block,
+  .post-header,
+  .print-review-banner,
+  .print-video-marker {
+    box-sizing: border-box !important;
+  }
+}
+
+/* [FLAGFIX-016 v2] Print layout rebalance:
+   wider column, title higher, denser draft banner, better page economy. */
+@media print {
+  main {
+    width: 18.2cm !important;
+    max-width: 100% !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    box-sizing: border-box !important;
+  }
+
+  .title-pt,
+  .title-en {
+    text-align: center !important;
+    margin-top: 0.2rem !important;
+    margin-bottom: 0.55rem !important;
+    line-height: 1.08 !important;
+  }
+
+  .post-header,
+  .content-block,
+  .print-review-banner,
+  .print-video-marker {
+    box-sizing: border-box !important;
+  }
+
+  .print-review-banner strong,
+  .print-review-banner b {
+    color: #333 !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.015em !important;
+  }
+
+  body {
+    font-size: 11pt !important;
+    line-height: 1.6 !important;
+  }
+
+  .content-block p,
+  .content-block li {
+    margin-top: 0.45rem !important;
+    margin-bottom: 0.45rem !important;
   }
 }


### PR DESCRIPTION
Implements the first print-review layout refinements for FlagFix Batch 01.

Scope:
- Rebalances A4 printable column width.
- Compacts and restyles the DRAFT/RASCUNHO review banner.
- Preserves PD#PN/page traceability through browser print headers/footers.
- Preserves Orange/Red doctrinal review markers.
- Updates both source SSG CSS and generated static CSS for immediate review.

Addresses:
- #26
- #28

Partially prepares:
- #27
- #29

No CSL rebuild was performed because this branch changes CSS-only print presentation.