### PR TITLE
docs: define Miccha Ditthi glossary protection policy

### DIFF
--- a/docs/FLAGFIX_009_MICCHA_DITTHI_GLOSSARY_PROTECTION_POLICY.md
+++ b/docs/FLAGFIX_009_MICCHA_DITTHI_GLOSSARY_PROTECTION_POLICY.md
@@ -1,0 +1,103 @@
+# FlagFix 009 — Micchā Diṭṭhi Glossary Protection Policy
+
+## Status
+
+Planning / review policy only.
+
+No title, translation, glossary, renderer, CSL, HTML, CSS, JavaScript, or static-site output changes are authorized by this document.
+
+## Problem
+
+The doctrinal term `Micchā Diṭṭhi` is especially sensitive because it is not merely a phrase to translate as ordinary language.
+
+Mechanical translation or normalization can distort meaning by:
+
+- removing Pāli diacritics;
+- replacing the term with an approximate English or Portuguese phrase;
+- flattening doctrinal nuance;
+- mixing title translation with glossary interpretation;
+- making inconsistent title/navigation labels;
+- weakening future multilingual preservation.
+
+## Principle
+
+`Micchā Diṭṭhi` must be treated as a protected source-bound doctrinal token.
+
+It may be accompanied by an approved explanatory translation, but the Pāli term itself must remain traceable and preserved unless human review explicitly authorizes a different rendering.
+
+## Protected forms
+
+The following forms require human review before any normalization:
+
+- `Micchā Diṭṭhi`
+- `micchā diṭṭhi`
+- `Miccha Ditthi`
+- `miccha ditthi`
+- mixed or partially diacritic forms
+
+Preferred canonical display, when applicable:
+
+```text
+Micchā Diṭṭhi
+````
+
+## Translation guardrail
+
+Do not automatically replace `Micchā Diṭṭhi` with:
+
+* wrong view
+* wrong views
+* visão errada
+* visão incorreta
+* entendimento errado
+* crença errada
+* false view
+* incorrect view
+
+These may be useful as explanatory glosses only after review.
+
+## Title guardrail
+
+If a title contains `Micchā Diṭṭhi`, the title must be reviewed before any correction.
+
+A title should not be mechanically title-cased, sentence-cased, translated, or simplified if doing so changes the protected term.
+
+## Glossary guardrail
+
+Any glossary entry for `Micchā Diṭṭhi` must preserve:
+
+* the Pāli term;
+* diacritics;
+* source context;
+* approved explanatory gloss;
+* reviewer decision;
+* downstream title/navigation impact.
+
+## Allowed actions
+
+Allowed from this document:
+
+1. document the protection rule;
+2. collect candidate occurrences;
+3. compare source and AXIS title forms;
+4. add review notes;
+5. propose a future implementation issue.
+
+## Forbidden actions
+
+Forbidden from this document:
+
+1. automatic title correction;
+2. automatic glossary rewrite;
+3. automatic translation substitution;
+4. renderer changes;
+5. CSL metadata changes;
+6. static-site output changes;
+7. bulk normalization of Pāli terms.
+
+## Acceptance criteria
+
+* Policy exists.
+* `Micchā Diṭṭhi` is documented as protected.
+* Translation/glossary/title risks are documented.
+* No title, glossary, renderer, CSL, HTML, CSS, JavaScript, or static-site output is changed.


### PR DESCRIPTION
Planning-only policy for FlagFix 009. 

Defines conservative Micchā Diṭṭhi glossary/title protection rules without changing titles, translation, glossary, renderer, CSL, HTML, CSS, JavaScript, or static-site output