### PR TITLE
docs: define future preservation layers policy

### DIFF
--- a/docs/FLAGFIX_001_FUTURE_PRESERVATION_LAYERS_POLICY.md
+++ b/docs/FLAGFIX_001_FUTURE_PRESERVATION_LAYERS_POLICY.md
@@ -1,0 +1,150 @@
+# FlagFix 001 — Future Preservation Layers Policy
+
+## Status
+
+Planning / review policy only.
+
+No renderer, CSL, HTML, CSS, JavaScript, navigation, metadata, pipeline, deployment, archive, retrieval, graph, AI, or static-site output changes are authorized by this document.
+
+## Purpose
+
+Define guardrails for future preservation layers before AXIS-NIDDHI expands beyond deterministic static publication into retrieval, study-order, graph, AI-assisted review, multilingual expansion, or long-term archival packaging.
+
+## Core Principle
+
+Future preservation layers must be additive, reversible, source-bound, and reviewable.
+
+No future layer may silently change canonical content, canonical identity, build determinism, source traceability, or publication behavior.
+
+## Layer Model
+
+Future preservation work should be separated into explicit layers:
+
+1. Source Layer
+   - original PureDhamma.net backup;
+   - extracted source HTML;
+   - source assets;
+   - source metadata.
+
+2. Canonical Source Library Layer
+   - stable PDPN identity;
+   - canonical content files;
+   - identity metadata;
+   - language-specific canonical artifacts.
+
+3. Review Layer
+   - human review notes;
+   - policy documents;
+   - issue-scoped matrices;
+   - source-bound decisions.
+
+4. Static Publication Layer
+   - generated pages;
+   - static assets;
+   - navigation/search artifacts;
+   - print/review output.
+
+5. Study Order Layer
+   - recommended reading sequence;
+   - path registry;
+   - prerequisite relationships;
+   - non-canonical study aids.
+
+6. Retrieval Layer
+   - source-bound context packs;
+   - concept registry;
+   - citation-preserving retrieval outputs;
+   - no unsupported generated claims.
+
+7. Graph Layer
+   - concept/order graph;
+   - dependency edges;
+   - relationship metadata;
+   - reviewable graph proposals.
+
+8. Multilingual Layer
+   - translation artifacts;
+   - protected term policies;
+   - glossary decisions;
+   - language-specific human review.
+
+9. Offline / Capsule Layer
+   - sealed static bundles;
+   - manifests;
+   - checksums;
+   - portable/offline review packages.
+
+10. AI-Assisted Layer
+   - source-bound prompts;
+   - dry-run outputs;
+   - insufficiency gates;
+   - no autonomous canonical edits.
+
+## Non-Negotiable Boundaries
+
+Future layers must not:
+
+- overwrite CSL content without explicit approved implementation scope;
+- infer doctrinal corrections automatically;
+- change PDPN identity;
+- change routes silently;
+- publish experimental outputs automatically;
+- mix review notes into canonical source text;
+- treat AI output as canonical evidence;
+- create hidden dependencies on proprietary services;
+- remove source traceability;
+- weaken deterministic build guarantees.
+
+## Required Review Before Implementation
+
+Before any future preservation layer is implemented, the issue must define:
+
+- target layer;
+- affected files;
+- canonical/non-canonical status;
+- source of truth;
+- review artifact;
+- rollback plan;
+- publication risk;
+- deployment impact;
+- whether Cloudflare output is affected.
+
+## Allowed Work Under This Policy
+
+Allowed:
+
+- documentation;
+- architecture diagrams;
+- review matrices;
+- inventory lists;
+- non-executing design notes;
+- source-bound examples;
+- future issue decomposition.
+
+Forbidden:
+
+- code changes;
+- pipeline changes;
+- build changes;
+- renderer changes;
+- CSL edits;
+- metadata rewrites;
+- automatic graph generation into production;
+- AI-generated canonical content;
+- static-site output changes.
+
+## Acceptance Criteria
+
+This policy is complete when:
+
+- future preservation layers are named;
+- canonical vs non-canonical boundaries are documented;
+- implementation guardrails are explicit;
+- no runtime or output files are changed;
+- future work requires separate approved issues.
+
+## Final Guardrail
+
+FlagFix 001 authorizes planning only.
+
+Future preservation layers may be imagined, documented, and reviewed here, but not implemented from this issue alone.


### PR DESCRIPTION
Planning-only policy for FlagFix 001. Defines future preservation layer guardrails without changing renderer, CSL, HTML, CSS, JavaScript, navigation, metadata, pipeline, deployment, archive, retrieval, graph, AI, or static-site output.