### PR TITLE
fix(print): constrain oversized images in review PDFs

### DIFF
--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -1389,6 +1389,17 @@ body[data-theme="stardust"] .csl-tattoo td {
     box-sizing: border-box !important;
   }
 
+  .content-block img {
+    display: block !important;
+    max-width: 100% !important;
+    height: auto !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    box-sizing: border-box !important;
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
+  }
+
   .print-review-banner strong,
   .print-review-banner b {
     color: #333 !important;

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -1389,6 +1389,17 @@ body[data-theme="stardust"] .csl-tattoo td {
     box-sizing: border-box !important;
   }
 
+  .content-block img {
+    display: block !important;
+    max-width: 100% !important;
+    height: auto !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    box-sizing: border-box !important;
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
+  }
+
   .print-review-banner strong,
   .print-review-banner b {
     color: #333 !important;


### PR DESCRIPTION
## Summary

Constrains oversized article images in print/PDF output so they cannot force horizontal overflow or browser shrink-to-fit behavior.

Addresses FLAGFIX_025 for BD.AA.007 and partially supports FLAGFIX_016 by preventing image-driven print overflow. Image sizing/aesthetic policy remains separate under FLAGFIX_014.

## Scope

- CSS-only
- print-only
- source-first static CSS
- no JS
- no templates
- no renderer
- no CSL
- no metadata
- no navigation
- no deployment or Cloudflare config changes

## Test evidence

Manual print preview testing on BD.AA.007 confirmed:

- the large figure no longer forces horizontal overflow
- Fit to page width and Scale 99% no longer drastically change document geometry
- the print column remains stable
- no JS, template, renderer, CSL, or pipeline change was needed

Recommended comparison pages:

- BD.AA.007
- TL.JJ.008
- BD.AA.002
- TL.EE.003

## Guardrails

This PR does not change content, canonical source, renderer behavior, JavaScript, templates, metadata, navigation, deployment configuration, Cloudflare configuration, or generated pages.

The static-site CSS mirror was intentionally updated because it is the served preview/publication CSS.

## Changed files

- pipeline/13-ssg/static/css/style.css
- pipeline/13-static-site/css/style.css

## Rollback plan

Revert this single commit. Rollback validation should confirm BD.AA.007 and the comparison pages still load, and print preview returns to the previous CSS behavior with no additional file changes.