### PR TITLE
fix(print): hide reading progress bar in PDFs

### DIFF
--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -731,6 +731,8 @@ footer { margin-top: 4.5rem; font-size: 0.85rem; opacity: 0.65; text-align: cent
   .theme-btn,
   .print-trigger,
   .mini-toc, .pathways, footer,
+  /* [FLAGFIX-017] Hide screen reading progress bar in printed/PDF copies. */
+  #reading-progress,
   #reading-progress-hook, #ai-assistant-hook,
   .digestibility-suggestion, .silent-pause-block,
   #search-form, #search-results, #print-modal, #print-modal-overlay, #labz-banner,

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -731,6 +731,8 @@ footer { margin-top: 4.5rem; font-size: 0.85rem; opacity: 0.65; text-align: cent
   .theme-btn,
   .print-trigger,
   .mini-toc, .pathways, footer,
+  /* [FLAGFIX-017] Hide screen reading progress bar in printed/PDF copies. */
+  #reading-progress,
   #reading-progress-hook, #ai-assistant-hook,
   .digestibility-suggestion, .silent-pause-block,
   #search-form, #search-results, #print-modal, #print-modal-overlay, #labz-banner,


### PR DESCRIPTION
## Summary

Hides the screen reading progress bar in print/PDF output.

This addresses FLAGFIX_017 by removing the accidental  leak that could appear as an inconsistent green line in printed review copies.

## Scope

- CSS-only
- print-only
- no JS
- no templates
- no renderer
- no CSL
- no metadata
- no navigation
- no deployment or Cloudflare config changes

## Guardrails

This PR does not implement the future decorative header/footer line feature. Any intentional print decoration should be designed separately as a controlled, optional, print-only feature and not coupled to the screen reading progress bar.

## Changed files

- pipeline/13-ssg/static/css/style.css
- pipeline/13-static-site/css/style.css

The static-site CSS mirror was intentionally updated because it is the served preview/publication CSS.

## Test evidence

Approved after visual test. Recommended print preview checks:

- TL.JJ.008
- TL.EE.003
- TL.DD.005
- BD.AA.007

Check with Fit to page width, Scale 99/100, and browser headers/footers on/off.

## Rollback plan

Revert this single commit to restore the previous print behavior.