### PR TITLE
fix(print): standardize h5 review heading style

### DIFF
--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -844,6 +844,31 @@ footer { margin-top: 4.5rem; font-size: 0.85rem; opacity: 0.65; text-align: cent
   header, .threshold-header { text-align: left !important; }
 }
 
+/* [FLAGFIX-024] Print-only content h5 review boxes.
+   Screen h5 collapse/expand behavior remains governed by the Sprint G rules above. */
+@media print {
+  .content-block h5 {
+    font-size: 12.5pt !important;
+    line-height: 1.32 !important;
+    font-weight: 600 !important;
+    color: #1a6b1a !important;
+    background: rgba(0, 128, 0, 0.055) !important;
+    border-left: 2pt solid #2d8a2d !important;
+    border-radius: 0 4pt 4pt 0 !important;
+    padding: 0.42rem 0.7rem 0.42rem 0.82rem !important;
+    margin: 1.35rem 0 0.55rem !important;
+    break-after: avoid !important;
+    page-break-after: avoid !important;
+  }
+
+  .content-block h5 span,
+  .content-block h5 strong,
+  .content-block h5 b {
+    font-size: inherit !important;
+    line-height: inherit !important;
+  }
+}
+
 /* =========================================================
    STEP 1 — DARK THEME LEGIBILITY + BOOK-GRADE TYPOGRAPHY
    [FF-009] 2026-03-09 · Aloka + Vayo · Sprint V5.5

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -844,6 +844,31 @@ footer { margin-top: 4.5rem; font-size: 0.85rem; opacity: 0.65; text-align: cent
   header, .threshold-header { text-align: left !important; }
 }
 
+/* [FLAGFIX-024] Print-only content h5 review boxes.
+   Screen h5 collapse/expand behavior remains governed by the Sprint G rules above. */
+@media print {
+  .content-block h5 {
+    font-size: 12.5pt !important;
+    line-height: 1.32 !important;
+    font-weight: 600 !important;
+    color: #1a6b1a !important;
+    background: rgba(0, 128, 0, 0.055) !important;
+    border-left: 2pt solid #2d8a2d !important;
+    border-radius: 0 4pt 4pt 0 !important;
+    padding: 0.42rem 0.7rem 0.42rem 0.82rem !important;
+    margin: 1.35rem 0 0.55rem !important;
+    break-after: avoid !important;
+    page-break-after: avoid !important;
+  }
+
+  .content-block h5 span,
+  .content-block h5 strong,
+  .content-block h5 b {
+    font-size: inherit !important;
+    line-height: inherit !important;
+  }
+}
+
 /* =========================================================
    STEP 1 — DARK THEME LEGIBILITY + BOOK-GRADE TYPOGRAPHY
    [FF-009] 2026-03-09 · Aloka + Vayo · Sprint V5.5


### PR DESCRIPTION
## Summary

Addresses FLAGFIX_024 by standardizing content H5 review heading styling in print/PDF output.

## Scope

- CSS-only
- print-only
- preserves online H5 collapsible behavior
- keeps H5 as an editorial review box
- does not implement a scientific essay style mode

## Test evidence

- visual test on localhost approved
- real printed output approved by reviewer

## Guardrails

- no JS changes
- no template changes
- no renderer changes
- no CSL changes
- no HTML generated page changes
- no metadata/navigation/deploy config changes
- inline span font-size inside H5 is neutralized only in print

## Changed files

- pipeline/13-ssg/static/css/style.css
- pipeline/13-static-site/css/style.css

The static-site CSS mirror was updated intentionally because it is the served/published CSS. Authorization received: sim, queremos publicar exatamente este build

## Rollback plan

Revert the single commit if the print H5 treatment needs to be backed out.