### PR TITLE
docs(flagfix): close FLAGFIX_024 resolution record

### DIFF
--- a/docs/FlagFix/FLAGFIX_024_PRINT_INCONSISTENCIA_VISUAL_TITULO_H5.md
+++ b/docs/FlagFix/FLAGFIX_024_PRINT_INCONSISTENCIA_VISUAL_TITULO_H5.md
@@ -209,3 +209,30 @@ Somente apresentação visual de headings internos.
 * `needs-audit`
 
 EOF
+
+## Resolution / Fechamento
+
+Status: implemented.
+
+Resolved by:
+
+- PR: #86
+- Commit: `d798a86`
+- Checkpoint: `checkpoint/flagfix-024-print-h5-standardization-20260504`
+
+Resolution summary:
+
+The print/PDF visual treatment for internal `h5` review headings was standardized with a print-only CSS patch.
+
+The fix preserves the online collapsible `h5` behavior and only changes print/PDF rendering.
+
+Touched implementation files:
+
+- `pipeline/13-ssg/static/css/style.css`
+- `pipeline/13-static-site/css/style.css`
+
+No renderer, CSL, JS, template, metadata, navigation, or deployment configuration changes were made.
+
+Future note:
+
+The current review-box style is accepted for the reviewer workflow. A more “scientific essay” style may be considered later as an optional print-design mode, but it is not urgent and is not part of this fix.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -14,7 +14,7 @@ This index is navigational only. The current directory layout is maintained by G
 | `docs/FlagFix/FLAGFIX_017_PRINT_GREEN_LINE_DECORATION_STANDARDIZATION.md` | Print green line decoration standardization | review scaffold | Tracks inconsistent green line decoration in printed review output. |
 | `docs/FlagFix/FLAGFIX_018_PRINT_DRAFT_BANNER_TYPOGRAPHY_GRAY_TONE.md` | Print draft banner typography and gray-tone design | review scaffold | Tracks archival/typewriter-style refinement for the DRAFT / RASCUNHO print banner. |
 | `docs/FlagFix/FLAGFIX_019_PRINT_PREV_NEXT_NAV_COMPACTION_AND_BOX_DESIGN.md` | Print previous/next navigation compaction | review scaffold | Tracks compact boxed print navigation and label treatment near the final page of essays. |
-| `docs/FlagFix/FLAGFIX_024_PRINT_INCONSISTENCIA_VISUAL_TITULO_H5.md` | Print H5 title visual inconsistency | review scaffold | Tracks visual inconsistency in internal H5 heading treatment in print/site output. |
+| `docs/FlagFix/FLAGFIX_024_PRINT_INCONSISTENCIA_VISUAL_TITULO_H5.md` | Print H5 title visual inconsistency | implemented | Resolved by PR #86 / commit `d798a86`; checkpoint `checkpoint/flagfix-024-print-h5-standardization-20260504`. |
 | `docs/FlagFix/FLAGFIX_025_PRINT_COMPACT_LAYOUT_BD_AA_007.md` | Compact print layout on BD.AA.007 | review scaffold | Tracks unusually narrow/compact print layout on the BD.AA.007 review page. |
 
 ## Batch 02 — Title and Metadata Integrity


### PR DESCRIPTION
## Summary

Closes the local FLAGFIX_024 resolution record after the implementation landed via PR #86.

## Scope

- docs-only
- closes local FLAGFIX_024 record
- marks FLAGFIX_024 as implemented in FLAGFIX_INDEX
- documents PR #86, commit d798a86, and checkpoint/flagfix-024-print-h5-standardization-20260504

## Guardrails

- no code changes
- no CSS changes
- no JS changes
- no pipeline changes
- no static-site output changes
- no deployment config changes

## Changed files

- docs/FlagFix/FLAGFIX_024_PRINT_INCONSISTENCIA_VISUAL_TITULO_H5.md
- docs/FlagFix/FLAGFIX_INDEX.md