### PR TITLE
docs(flagfix): close FLAGFIX_016 resolution record

### DIFF
--- a/docs/FlagFix/FLAGFIX_016_PRINT_MARGIN_CONTENT_WIDTH_ALIGNMENT.md
+++ b/docs/FlagFix/FLAGFIX_016_PRINT_MARGIN_CONTENT_WIDTH_ALIGNMENT.md
@@ -212,3 +212,19 @@ Acceptance:
 - no clipping;
 - no horizontal overflow;
 - no screen layout regression.
+
+---
+
+## Resolution / Fechamento
+
+Status: closed / no additional global patch recommended now.
+
+Current decision:
+
+- the current print margin and content-width behavior is acceptable after related print fixes;
+- PR #84 addressed the urgent image-driven overflow / shrink-to-fit case that affected global print geometry;
+- no additional global margin or content-width patch is recommended at this time;
+- future page-specific evidence may open a new targeted issue;
+- no CSS, JavaScript, renderer, CSL, pipeline, or static-site output change is authorized by this record.
+
+This record remains useful as historical review context, but it does not currently require implementation.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -10,7 +10,7 @@ This index is navigational only. The current directory layout is maintained by G
 |---|---|---|---|
 | `docs/FlagFix/FLAGFIX_BATCH_01_PRINT_REVIEW_UX_PLAN.md` | Print Review UX batch plan | discussion | Existing Batch 01 planning record; included here for inventory completeness. |
 | `docs/FlagFix/FLAGFIX_006_PRINT_NAV_LABEL_LOCALIZATION.md` | Print navigation label localization | review scaffold | Tracks English `From` / `To` labels appearing in printed/PDF review navigation. |
-| `docs/FlagFix/FLAGFIX_016_PRINT_MARGIN_CONTENT_WIDTH_ALIGNMENT.md` | Print margins and optical centering | review scaffold | Tracks print/PDF content width and left/right margin balance. |
+| `docs/FlagFix/FLAGFIX_016_PRINT_MARGIN_CONTENT_WIDTH_ALIGNMENT.md` | Print margins and optical centering | closed / no additional global patch recommended now | Current print margin/content-width behavior is acceptable after related fixes; PR #84 resolved the urgent image-driven overflow case. |
 | `docs/FlagFix/FLAGFIX_017_PRINT_GREEN_LINE_DECORATION_STANDARDIZATION.md` | Print green line decoration standardization | review scaffold | Tracks inconsistent green line decoration in printed review output. |
 | `docs/FlagFix/FLAGFIX_018_PRINT_DRAFT_BANNER_TYPOGRAPHY_GRAY_TONE.md` | Print draft banner typography and gray-tone design | closed / no implementation recommended now | Current banner behavior is acceptable for review workflow; future typography or print-menu polish may be handled separately. |
 | `docs/FlagFix/FLAGFIX_019_PRINT_PREV_NEXT_NAV_COMPACTION_AND_BOX_DESIGN.md` | Print previous/next navigation compaction | review scaffold | Tracks compact boxed print navigation and label treatment near the final page of essays. |


### PR DESCRIPTION
## Summary

Adds a docs-only resolution record for FLAGFIX_016 and updates the FlagFix index.

## Scope

- docs-only
- no implementation
- no CSS changes
- no JS changes
- no renderer, CSL, pipeline, or static-site output changes

## Decision

- current print margin/content-width behavior is acceptable after related fixes
- PR #84 addressed the urgent image-driven overflow / shrink-to-fit case
- no additional global margin/content-width patch is recommended now
- future page-specific evidence may open a new targeted issue

## Guardrails

This PR does not authorize CSS, JS, renderer, CSL, pipeline, static-site output, metadata, navigation, deployment, or Cloudflare changes.

## Changed files

- docs/FlagFix/FLAGFIX_016_PRINT_MARGIN_CONTENT_WIDTH_ALIGNMENT.md
- docs/FlagFix/FLAGFIX_INDEX.md