### PR TITLE
docs(flagfix): add Batch 01 closure record

### DIFF
--- a/docs/FlagFix/FLAGFIX_BATCH_01_CLOSURE_RECORD_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_BATCH_01_CLOSURE_RECORD_2026-05-04.md
@@ -1,0 +1,74 @@
+# AXIS-NIDDHI — FLAGFIX Batch 01 Closure Record
+
+**Date:** 2026-05-04  
+**Status:** Closure record / No implementation  
+**Scope:** Batch 01 — Print Review UX  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This document records the operational closure state for Batch 01 — Print Review UX.
+
+It is a docs-only closure record. It does not authorize code, CSS, JavaScript, renderer, CSL, pipeline, static-site output, metadata, navigation, deployment, or Cloudflare changes.
+
+---
+
+## Final Batch 01 State
+
+| FlagFix | Final state |
+|---|---|
+| `FLAGFIX_006` | Closed / neutralized by current print hiding. |
+| `FLAGFIX_016` | Closed / verified current print behavior. |
+| `FLAGFIX_017` | Fixed via PR #85. |
+| `FLAGFIX_018` | Closed / no implementation recommended now / polish pending. |
+| `FLAGFIX_019` | Closed / neutralized by current print hiding. |
+| `FLAGFIX_024` | Fixed via PR #86 and documented via PR #87. |
+| `FLAGFIX_025` | Fixed via PR #84. |
+
+---
+
+## Batch Decisions
+
+The print review workflow remains pt-BR focused.
+
+Final navigation blocks remain hidden from print/PDF.
+
+The reading progress bar is hidden from print/PDF.
+
+Oversized images are constrained in print to prevent shrink-to-fit geometry issues.
+
+H5 headings are standardized for print review while preserving online collapsible behavior.
+
+The review banner typography is acceptable for now, with future polish separated.
+
+No further Batch 01 implementation is recommended unless new page-specific evidence appears.
+
+---
+
+## Guardrails
+
+This closure record does not authorize:
+
+- manual CSL edits;
+- manual static-site page edits;
+- renderer changes;
+- pipeline changes;
+- CSS changes;
+- JavaScript changes;
+- template changes;
+- metadata changes;
+- navigation changes;
+- deployment or Cloudflare configuration changes;
+- static-site output changes.
+
+Future print-mode menus, prompts, design modes, or options must be handled as separate feature work.
+
+---
+
+## Next Review Gate
+
+If new page-specific print evidence appears, open a targeted issue, branch, and PR.
+
+Do not reopen Batch 01 as a broad implementation bucket unless a new review gate explicitly approves that scope.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -9,6 +9,7 @@ This index is navigational only. The current directory layout is maintained by G
 | Path | Theme | Status | Observation |
 |---|---|---|---|
 | `docs/FlagFix/FLAGFIX_BATCH_01_PRINT_REVIEW_UX_PLAN.md` | Print Review UX batch plan | discussion | Existing Batch 01 planning record; included here for inventory completeness. |
+| `docs/FlagFix/FLAGFIX_BATCH_01_CLOSURE_RECORD_2026-05-04.md` | Batch 01 closure record | checkpoint | Records final Print Review UX closure state, global decisions, and guardrails; no implementation is authorized here. |
 | `docs/FlagFix/FLAGFIX_006_PRINT_NAV_LABEL_LOCALIZATION.md` | Print navigation label localization | review scaffold | Tracks English `From` / `To` labels appearing in printed/PDF review navigation. |
 | `docs/FlagFix/FLAGFIX_016_PRINT_MARGIN_CONTENT_WIDTH_ALIGNMENT.md` | Print margins and optical centering | closed / no additional global patch recommended now | Current print margin/content-width behavior is acceptable after related fixes; PR #84 resolved the urgent image-driven overflow case. |
 | `docs/FlagFix/FLAGFIX_017_PRINT_GREEN_LINE_DECORATION_STANDARDIZATION.md` | Print green line decoration standardization | review scaffold | Tracks inconsistent green line decoration in printed review output. |


### PR DESCRIPTION
## Summary

Adds a docs-only closure record for FLAGFIX Batch 01 — Print Review UX and updates the FlagFix index.

## Scope

- docs-only
- closure-record-only
- no implementation
- no CSS changes
- no JS changes
- no renderer, CSL, pipeline, or static-site output changes

## Batch 01 Closure

- FLAGFIX_006: closed / neutralized by current print hiding
- FLAGFIX_016: closed / verified current print behavior
- FLAGFIX_017: fixed via PR #85
- FLAGFIX_018: closed / no implementation recommended now / polish pending
- FLAGFIX_019: closed / neutralized by current print hiding
- FLAGFIX_024: fixed via PR #86 and documented via PR #87
- FLAGFIX_025: fixed via PR #84

## Guardrails

This PR does not authorize manual CSL edits, manual static-site page edits, renderer changes, pipeline changes, CSS changes, JS changes, template changes, metadata changes, navigation changes, deployment or Cloudflare changes, or static-site output changes.

Future print-mode menus/options must be handled as separate feature work.

## Changed files

- docs/FlagFix/FLAGFIX_BATCH_01_CLOSURE_RECORD_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md