### PR TITLE
docs(flagfix): add FLAGFIX_020 title matrix expansion plan

### DIFF
--- a/docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_EXPANSION_PLAN_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_EXPANSION_PLAN_2026-05-04.md
@@ -1,0 +1,209 @@
+# AXIS-NIDDHI — FLAGFIX_020 Title Matrix Expansion Plan
+
+**Date:** 2026-05-04  
+**Status:** Plan-only / No implementation  
+**Scope:** Controlled expansion of the title comparison matrix  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This document defines a docs-only plan for expanding the `FLAGFIX_020` Title Comparison Matrix in a controlled human-review workflow.
+
+The matrix exists to compare:
+
+- PureDhamma original title;
+- PureDhamma slug / URL;
+- AXIS en-US title;
+- AXIS pt-BR title;
+- AXIS URL;
+- issue type;
+- human note;
+- final human decision.
+
+This plan does not authorize title corrections, CSV expansion, scripts, code changes, metadata changes, static-site output changes, or rebuilds.
+
+---
+
+## Current State
+
+The seed matrix exists:
+
+```text
+review/title-matrix/flagfix_020_title_comparison_matrix.csv
+```
+
+It currently has a header plus seed rows for:
+
+```text
+TL.EE.008
+TL.EE.011
+```
+
+It is a pilot human-review artifact, not an implementation artifact.
+
+No title should be corrected automatically from the current matrix.
+
+---
+
+## Related Policies
+
+The matrix is the coordination artifact for several Batch 02 title policies:
+
+- `FLAGFIX_007` — title glossary / Pāli protection;
+- `FLAGFIX_011` — punctuation preservation;
+- `FLAGFIX_012` — slug/title divergence;
+- `FLAGFIX_013` — pt-BR title capitalization.
+
+These policies inform review classification. They do not authorize automatic correction.
+
+---
+
+## Guardrails
+
+This plan does not authorize:
+
+- automatic title correction;
+- CSL edits;
+- `identity.json` edits;
+- `SP02` changes;
+- `SP11` changes;
+- renderer changes;
+- SSG functional changes;
+- metadata operational changes;
+- static-site output changes;
+- rebuilds;
+- mass title rewrites.
+
+The safe default remains:
+
+```text
+Preserve first. Compare second. Correct only after human review.
+```
+
+---
+
+## Expansion Workflow
+
+### Step 1 — Validate Matrix Columns and Decision Vocabulary
+
+Confirm the matrix columns are sufficient for human review.
+
+Recommended required fields:
+
+- `PDPN`;
+- `puredhamma_original_title`;
+- `puredhamma_slug`;
+- `puredhamma_url`;
+- `axis_en_title`;
+- `axis_pt_title`;
+- `axis_url`;
+- `issue_type`;
+- `human_reviewer_note`;
+- `decision`.
+
+Confirm the decision vocabulary before adding more rows.
+
+### Step 2 — Add a Small Pilot Batch of Title Cases
+
+Add a small pilot batch from known policy examples.
+
+Good candidates include titles flagged by:
+
+- punctuation loss;
+- slug/title divergence;
+- Pāli or glossary term protection;
+- pt-BR capitalization concerns;
+- title fallback from slug;
+- translation review concerns.
+
+The pilot should be small enough for human review before any correction issue is opened.
+
+### Step 3 — Human Review
+
+A human reviewer should mark:
+
+- issue type;
+- review note;
+- final decision.
+
+The decision should distinguish between:
+
+- no action;
+- accepted divergence;
+- needs title correction;
+- needs slug/source verification;
+- needs doctrinal/Pāli review;
+- needs downstream implementation issue.
+
+### Step 4 — Open Targeted Correction Issues Only After Review
+
+Only after a human decision should targeted correction issues be opened.
+
+Each correction issue should name the exact PD#PN rows, the approved title decision, the expected changed files, and the rollback strategy.
+
+---
+
+## Recommended Issue Types
+
+Use a controlled issue-type vocabulary:
+
+- `punctuation_loss`;
+- `slug_title_divergence`;
+- `pali_term_protection`;
+- `pt_capitalization`;
+- `title_missing`;
+- `title_fallback_from_slug`;
+- `translation_review`;
+- `no_action`.
+
+Additional values may be added later, but should be documented before use.
+
+---
+
+## Candidate Data Sources
+
+Candidate read-only sources for future matrix expansion:
+
+```text
+pipeline/13-static-site/search_index.json
+pipeline/13-static-site/pages/<PDPN>/index.html
+pipeline/metadata/Translation_Control_Center.csv
+pipeline/metadata/Print_Translation_Control_Center.csv
+review/title-matrix/flagfix_020_title_comparison_matrix.csv
+```
+
+These sources may support review data collection. They do not authorize editing generated output or metadata.
+
+---
+
+## Out of Scope
+
+This plan excludes:
+
+- direct correction of titles;
+- DeepL/API translation;
+- automatic normalization;
+- renderer changes;
+- pipeline changes;
+- metadata changes;
+- SSG functional changes;
+- rebuild/publication;
+- static-site output changes.
+
+CSV expansion is also out of scope for this plan PR. It should happen in a separate review artifact PR.
+
+---
+
+## Next Review Gate
+
+Future matrix expansion should use a dedicated branch and PR.
+
+That PR should state:
+
+- exact rows added;
+- source evidence used;
+- issue-type vocabulary used;
+- whether all rows are review-only;
+- confirmation that no title corrections or generated output changes are included.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -27,6 +27,7 @@ This index is navigational only. The current directory layout is maintained by G
 | `docs/FlagFix/FLAGFIX_012_SLUG_TITLE_DIVERGENCE_POLICY.md` | Slug/title divergence | policy | Prevents slug-derived titles from overriding source title semantics. |
 | `docs/FlagFix/FLAGFIX_013_PT_TITLE_CAPITALIZATION_POLICY.md` | Portuguese title capitalization | policy | Defines conservative pt-BR title casing review rules. |
 | `docs/FlagFix/FLAGFIX_020_TITLE_COMPARISON_MATRIX.md` | Human title comparison workflow | review scaffold | Defines the review matrix before any title correction is considered. |
+| `docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_EXPANSION_PLAN_2026-05-04.md` | Title comparison matrix expansion plan | discussion | Plans controlled pilot expansion of the human-review matrix; no title corrections, scripts, metadata changes, or rebuilds are authorized here. |
 | `review/title-matrix/flagfix_020_title_comparison_matrix.csv` | Seed title comparison matrix | review scaffold | Contains initial human-review rows and decisions; no correction is authorized by the CSV alone. |
 | `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_REVIEW.md` | Missing or ambiguous date metadata | review scaffold | Documents date visibility review tasks before automated correction. |
 | `docs/FlagFix/FLAGFIX_021_MISSING_DATE_REVIEW_BOX_POLICY.md` | Missing date review box behavior | policy | Sets conservative display policy for date review boxes and source-date uncertainty. |


### PR DESCRIPTION
## Summary

Adds a docs-only plan for controlled expansion of the FLAGFIX_020 Title Comparison Matrix and updates the FlagFix index.

## Scope

- docs-only
- plan-only
- no title corrections
- no CSV expansion yet
- no scripts
- no code changes
- no metadata changes
- no static-site output changes
- no rebuild

## Guardrails

This PR does not touch CSL, identity.json, SP02, SP11, renderer, SSG functional code, operational metadata, static-site output, or generated pages.

No automatic title correction, DeepL/API translation, automatic normalization, mass rewrite, rebuild, or publication is authorized.

## Expected changed files

- docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_EXPANSION_PLAN_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md