### PR TITLE
docs(flagfix): add FLAGFIX_020 pilot checkpoint

### DIFF
--- a/docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_PILOT_CHECKPOINT_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_PILOT_CHECKPOINT_2026-05-04.md
@@ -1,0 +1,115 @@
+# AXIS-NIDDHI — FLAGFIX_020 Title Matrix Pilot Checkpoint
+
+**Date:** 2026-05-04  
+**Status:** Checkpoint / No implementation  
+**Scope:** FLAGFIX_020 title comparison matrix pilot state  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This document records the state of `FLAGFIX_020` after the controlled pilot expansion of the title comparison matrix.
+
+It is a docs-only checkpoint. It does not authorize title corrections, CSV changes, scripts, code changes, metadata changes, static-site output changes, or rebuilds.
+
+---
+
+## Matrix Location
+
+The matrix exists at:
+
+```text
+review/title-matrix/flagfix_020_title_comparison_matrix.csv
+```
+
+Current state:
+
+```text
+pilot expanded / human review pending
+```
+
+Current total:
+
+```text
+header + 6 rows
+```
+
+---
+
+## Original Seed Rows
+
+The original seed rows are:
+
+| PD#PN | Role |
+|---|---|
+| `TL.EE.008` | Seed title punctuation / semantic preservation / translation risk case. |
+| `TL.EE.011` | Seed missing or ambiguous date metadata context case. |
+
+---
+
+## PR #98 Pilot Expansion Rows
+
+PR #98 added four review-only pilot rows:
+
+| PD#PN | Issue type |
+|---|---|
+| `TL.CC.003` | `punctuation_loss` |
+| `TL.BB.002` | `slug_title_divergence` |
+| `TL.CC.004` | `pt_capitalization` |
+| `TL.BB.005` | `pali_term_protection` |
+
+All new rows are marked:
+
+```text
+decision=review_pending
+```
+
+No title correction was applied.
+
+---
+
+## Current Decision
+
+Do not expand the matrix in bulk yet.
+
+The next step is human review of the six current rows.
+
+Future corrections must become targeted issues and PRs.
+
+This checkpoint does not authorize changes to:
+
+- CSL;
+- `identity.json`;
+- `SP02`;
+- `SP11`;
+- renderer behavior;
+- metadata;
+- static-site output;
+- rebuild/publication.
+
+---
+
+## Guardrails
+
+This checkpoint does not authorize:
+
+- automatic title correction;
+- direct title correction;
+- CSV expansion;
+- scripts;
+- code changes;
+- metadata changes;
+- static-site output changes;
+- rebuilds;
+- mass title rewrites.
+
+The matrix remains a human-review artifact only.
+
+---
+
+## Next Review Gate
+
+Before any implementation, reviewers should decide each current matrix row.
+
+Only rows with explicit human approval should become downstream correction issues or implementation PRs.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -28,6 +28,7 @@ This index is navigational only. The current directory layout is maintained by G
 | `docs/FlagFix/FLAGFIX_013_PT_TITLE_CAPITALIZATION_POLICY.md` | Portuguese title capitalization | policy | Defines conservative pt-BR title casing review rules. |
 | `docs/FlagFix/FLAGFIX_020_TITLE_COMPARISON_MATRIX.md` | Human title comparison workflow | review scaffold | Defines the review matrix before any title correction is considered. |
 | `docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_EXPANSION_PLAN_2026-05-04.md` | Title comparison matrix expansion plan | discussion | Plans controlled pilot expansion of the human-review matrix; no title corrections, scripts, metadata changes, or rebuilds are authorized here. |
+| `docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_PILOT_CHECKPOINT_2026-05-04.md` | Title comparison matrix pilot checkpoint | checkpoint | Records matrix state after PR #98: header plus six rows, human review pending, and no title corrections applied. |
 | `review/title-matrix/flagfix_020_title_comparison_matrix.csv` | Seed title comparison matrix | review scaffold | Contains initial human-review rows and decisions; no correction is authorized by the CSV alone. |
 | `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_REVIEW.md` | Missing or ambiguous date metadata | review scaffold | Documents date visibility review tasks before automated correction. |
 | `docs/FlagFix/FLAGFIX_021_MISSING_DATE_REVIEW_BOX_POLICY.md` | Missing date review box behavior | policy | Sets conservative display policy for date review boxes and source-date uncertainty. |


### PR DESCRIPTION
## Summary

Adds a docs-only checkpoint for FLAGFIX_020 after the pilot expansion of the title comparison matrix.

## Scope

- docs-only
- checkpoint-only
- no title corrections
- no CSV changes
- no scripts
- no code changes
- no metadata changes
- no static-site output changes
- no rebuild

## Checkpoint

- matrix location: review/title-matrix/flagfix_020_title_comparison_matrix.csv
- current state: pilot expanded / human review pending
- current total: header + 6 rows
- original seed rows: TL.EE.008, TL.EE.011
- PR #98 rows: TL.CC.003, TL.BB.002, TL.CC.004, TL.BB.005
- all PR #98 rows use decision=review_pending
- no title correction was applied

## Guardrails

This PR does not authorize changes to CSL, identity.json, SP02, SP11, renderer, metadata, static-site output, or rebuild/publication.

Future corrections must become targeted issues and PRs after human review.

## Changed files

- docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_PILOT_CHECKPOINT_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md