### PR TITLE
review(flagfix): add FLAGFIX_021 missing date metadata audit

### DIFF
--- a/docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_AUDIT_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_AUDIT_2026-05-04.md
@@ -1,0 +1,134 @@
+# AXIS-NIDDHI — FLAGFIX_021 Missing Date Metadata Audit
+
+**Date:** 2026-05-04  
+**Status:** Audit-only / Human review pending  
+**Scope:** Date visibility inventory for Batch 02  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This audit records the current state of visible date metadata for `FLAGFIX_021 — Missing Date Metadata Review`.
+
+It inventories pages with a visible date-like string near the top of the rendered article, pages that do not expose such a date-like string at the top, and cases where only comment metadata is currently detectable.
+
+No date was corrected, inferred, normalized, or backfilled for this audit.
+
+---
+
+## Audit Totals
+
+- Total pages scanned: `748`
+- Pages with a visible date-like string near the top: `685`
+- Candidate pages without a visible date-like string near the top: `63`
+- Review box present in current output: `no`
+
+The current output does not include a dedicated missing-date review box.
+
+The existing policy and review scaffold remain documentation only; they do not implement visual handling in the current production output.
+
+---
+
+## Audit Artifact
+
+CSV audit artifact:
+
+- `review/date-metadata/flagfix_021_missing_date_metadata_audit.csv`
+
+This CSV intentionally records a small reviewable subset instead of a mass export:
+
+- `24` candidate pages sampled from the larger pool of `63` heuristic candidates
+- `1` control row with a visible top date (`TL.EE.008`)
+
+This keeps the first pass small enough for safe human review while preserving the known totals from the broader scan.
+
+---
+
+## Key Findings
+
+### 1. Review box behavior is not implemented
+
+No current page output was found with a dedicated missing-date review box or equivalent structured warning.
+
+### 2. Visible dates are currently content-driven
+
+Where dates appear, they are usually present as article-body content near the top of the English rendering rather than as a dedicated template metadata field.
+
+### 3. Comment-only metadata exists in some cases
+
+Some pages expose date-related clues only in comments such as:
+
+- `Date:`
+- `Extraction:`
+- `Source-Ref:`
+
+This is not the same as a reader-visible date in the rendered article.
+
+### 4. No remediation is authorized yet
+
+This audit is strictly inventory work.
+
+It does not authorize:
+
+- date correction;
+- date inference;
+- CSL edits;
+- `identity.json` edits;
+- renderer or template changes;
+- metadata operational changes;
+- static-site output edits;
+- rebuild/publication work.
+
+---
+
+## Included Reference Cases
+
+### `TL.EE.011`
+
+- No visible date-like string was detected at the top of the current English article.
+- Comment metadata is still present (`Date:` / `Extraction:`).
+- This is recorded as `pt_comment_only` and remains `review_pending`.
+
+### `TL.EE.008`
+
+- Visible top date is present:
+  - `July 24, 2022; revised December 14, 2022; February 26, 2025`
+- Comment metadata is also present.
+- This row is included as a control case and remains `review_pending`.
+
+---
+
+## Current Decision
+
+- The current policy is not yet implemented in production output.
+- No date correction or inference is recommended now.
+- The next step is human review of the audit CSV before any patch or visual policy work is considered.
+- Any future implementation must happen in a separate issue, branch, and PR.
+
+---
+
+## Guardrails
+
+This audit does not authorize:
+
+- title or date correction;
+- missing-date inference;
+- manual edits to generated HTML pages;
+- manual edits to CSL or `identity.json`;
+- renderer, template, or pipeline functional changes;
+- metadata operational changes;
+- static-site output changes;
+- rebuild/publication.
+
+---
+
+## Next Review Gate
+
+Before any future implementation, require:
+
+1. human review of the audit CSV;
+2. explicit confirmation of which date states are acceptable;
+3. explicit candidate files for any proposed implementation;
+4. explicit decision on whether rebuild/static-site publication would be required;
+5. rollback plan for any visual or metadata behavior change.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -32,6 +32,8 @@ This index is navigational only. The current directory layout is maintained by G
 | `review/title-matrix/flagfix_020_title_comparison_matrix.csv` | Seed title comparison matrix | review scaffold | Contains initial human-review rows and decisions; no correction is authorized by the CSV alone. |
 | `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_REVIEW.md` | Missing or ambiguous date metadata | review scaffold | Documents date visibility review tasks before automated correction. |
 | `docs/FlagFix/FLAGFIX_021_MISSING_DATE_REVIEW_BOX_POLICY.md` | Missing date review box behavior | policy | Sets conservative display policy for date review boxes and source-date uncertainty. |
+| `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_AUDIT_2026-05-04.md` | Missing date metadata audit | checkpoint | Records the current audit totals for visible top dates versus candidate missing-date pages; no date correction or inference is authorized here. |
+| `review/date-metadata/flagfix_021_missing_date_metadata_audit.csv` | Missing date metadata audit CSV | review scaffold | Small reviewable subset from the current date-visibility audit, including control and comment-only cases; human review remains pending. |
 
 ## Batch 03 — Pāli Protection
 

--- a/review/date-metadata/flagfix_021_missing_date_metadata_audit.csv
+++ b/review/date-metadata/flagfix_021_missing_date_metadata_audit.csv
@@ -1,0 +1,26 @@
+pdpn,axis_url,has_visible_date_top,detected_date_text,has_pt_date_comment,has_source_ref_comment,has_extraction_comment,issue_type,human_note,decision
+AB.AA.000,pages/AB.AA.000/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+AB.CC.001,pages/AB.CC.001/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+AB.DD.001,pages/AB.DD.001/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+AB.EE.001,pages/AB.EE.001/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+AB.GG.002,pages/AB.GG.002/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+AB.GG.003,pages/AB.GG.003/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+BC.AA.000,pages/BC.AA.000/index.html,false,,false,false,false,missing_visible_date,"Section-introduction page; no top date-like string detected in current output.",review_pending
+BC.AA.003,pages/BC.AA.003/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+BD.AA.000,pages/BD.AA.000/index.html,false,,false,false,false,missing_visible_date,"Section-introduction page; no top date-like string detected in current output.",review_pending
+BD.AA.009,pages/BD.AA.009/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+BD.CC.001,pages/BD.CC.001/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+BD.II.001,pages/BD.II.001/index.html,false,,false,false,false,missing_visible_date,"Subsection-introduction style page; no top date-like string detected in current output.",review_pending
+BD.II.002,pages/BD.II.002/index.html,false,,false,false,false,missing_visible_date,"Subsection-introduction style page; no top date-like string detected in current output.",review_pending
+BM.AA.002,pages/BM.AA.002/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+BM.AA.003,pages/BM.AA.003/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+BM.BB.001,pages/BM.BB.001/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+BM.BB.002,pages/BM.BB.002/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+DD.AA.000,pages/DD.AA.000/index.html,false,,false,false,false,missing_visible_date,"Section-introduction page; no top date-like string detected in current output.",review_pending
+DP.AA.000,pages/DP.AA.000/index.html,false,,false,false,false,missing_visible_date,"Section-introduction page; no top date-like string detected in current output.",review_pending
+DP.AA.001,pages/DP.AA.001/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+DP.AA.002,pages/DP.AA.002/index.html,false,,false,false,false,missing_visible_date,"No date-like string detected at the top of the EN article by the current heuristic.",review_pending
+DS.AA.000,pages/DS.AA.000/index.html,false,,false,false,false,missing_visible_date,"Section-introduction page; no top date-like string detected in current output.",review_pending
+DS.AA.002,pages/DS.AA.002/index.html,false,,false,false,false,missing_visible_date,"Subsection-introduction style page; no top date-like string detected in current output.",review_pending
+TL.EE.011,pages/TL.EE.011/index.html,false,,true,false,true,pt_comment_only,"No visible top date detected in the current EN article; translation/extraction comments exist and need human review.",review_pending
+TL.EE.008,pages/TL.EE.008/index.html,true,"July 24, 2022; revised December 14, 2022; February 26, 2025",true,false,true,visible_date_present,"Control row with visible top date and comment metadata present.",review_pending


### PR DESCRIPTION
## Summary

Adds a docs/CSV audit for FLAGFIX_021 to inventory pages with visible top dates, comment-only date metadata, and candidate missing-date cases.

## Scope

- audit-only
- docs/CSV only
- no implementation
- no date correction or inference

## Guardrails

This PR does not authorize renderer, template, CSS, JS, CSL, identity, operational metadata, static-site output, or rebuild changes.

## Changed files

- docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_AUDIT_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md
- review/date-metadata/flagfix_021_missing_date_metadata_audit.csv

## Audit notes

- scanned pages: 748
- visible date-like string near top: 685
- candidate pages without visible top date: 63
- current CSV is a reviewable subset plus a control row
- review box behavior is not implemented in current output