### PR TITLE
docs(flagfix): add FLAGFIX_021 audit checkpoint

### DIFF
--- a/docs/FlagFix/FLAGFIX_021_DATE_METADATA_AUDIT_CHECKPOINT_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_021_DATE_METADATA_AUDIT_CHECKPOINT_2026-05-04.md
@@ -1,0 +1,87 @@
+# AXIS-NIDDHI — FLAGFIX_021 Date Metadata Audit Checkpoint
+
+**Date:** 2026-05-04  
+**Status:** Checkpoint / Human review pending  
+**Scope:** Post-audit state record for missing date metadata review  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This checkpoint records the state of `FLAGFIX_021` after the initial date metadata audit was created.
+
+It exists to freeze the current audit totals, confirm the review posture, and document that the project remains in inventory mode rather than implementation mode.
+
+---
+
+## Recorded State
+
+- Total pages scanned: `748`
+- Pages with a visible top date-like string: `685`
+- Candidate pages missing a visible top date-like string: `63`
+- Audit CSV subset size: `25` rows
+
+The current audit subset includes:
+
+- `TL.EE.011` as a missing/comment-only case
+- `TL.EE.008` as a visible-date control case
+
+No date correction or date inference was performed.
+
+---
+
+## Current Audit Artifacts
+
+- `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_AUDIT_2026-05-04.md`
+- `review/date-metadata/flagfix_021_missing_date_metadata_audit.csv`
+
+The CSV remains a small reviewable subset rather than a mass-export of all `63` candidate pages.
+
+---
+
+## Current Product State
+
+- A dedicated date review box is **not implemented** in current output.
+- Human review is still pending.
+- The policy exists, but it is not yet implemented in production behavior.
+
+At this stage, the audit should be treated as a review aid, not as implementation authorization.
+
+---
+
+## Decision
+
+- No implementation is recommended now.
+- No review box should be introduced before human review of the audit set.
+- Any future implementation requires a separate issue, branch, and PR.
+- No CSL, `identity.json`, renderer, template, metadata, static-site output, or rebuild work is authorized by this checkpoint.
+
+---
+
+## Guardrails
+
+This checkpoint does not authorize:
+
+- date correction;
+- date inference;
+- renderer changes;
+- template changes;
+- CSS or JavaScript changes;
+- CSL edits;
+- `identity.json` edits;
+- metadata operational changes;
+- static-site output changes;
+- rebuild/publication work.
+
+---
+
+## Next Review Gate
+
+Before any future implementation:
+
+1. review the `25` CSV rows manually;
+2. confirm which missing/ambiguous date states are acceptable;
+3. identify candidate implementation files explicitly;
+4. decide whether any rebuild/publication path would be required;
+5. document rollback expectations before code work begins.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -33,6 +33,7 @@ This index is navigational only. The current directory layout is maintained by G
 | `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_REVIEW.md` | Missing or ambiguous date metadata | review scaffold | Documents date visibility review tasks before automated correction. |
 | `docs/FlagFix/FLAGFIX_021_MISSING_DATE_REVIEW_BOX_POLICY.md` | Missing date review box behavior | policy | Sets conservative display policy for date review boxes and source-date uncertainty. |
 | `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_AUDIT_2026-05-04.md` | Missing date metadata audit | checkpoint | Records the current audit totals for visible top dates versus candidate missing-date pages; no date correction or inference is authorized here. |
+| `docs/FlagFix/FLAGFIX_021_DATE_METADATA_AUDIT_CHECKPOINT_2026-05-04.md` | Missing date metadata audit checkpoint | checkpoint | Freezes the post-audit state: 748 pages scanned, 63 candidates, 25 CSV rows, review box absent, and human review still pending. |
 | `review/date-metadata/flagfix_021_missing_date_metadata_audit.csv` | Missing date metadata audit CSV | review scaffold | Small reviewable subset from the current date-visibility audit, including control and comment-only cases; human review remains pending. |
 
 ## Batch 03 — Pāli Protection


### PR DESCRIPTION
## Summary

Adds a docs-only checkpoint for FLAGFIX_021 after the initial date metadata audit.

## Scope

- docs-only
- checkpoint-only
- no implementation
- no CSV changes
- no date correction or inference

## Guardrails

This PR does not authorize CSL, identity, renderer, template, metadata, static-site output, or rebuild changes. It also does not authorize a review box implementation.

## Changed files

- docs/FlagFix/FLAGFIX_021_DATE_METADATA_AUDIT_CHECKPOINT_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md