### PR TITLE
docs(flagfix): add Batch 02 partial checkpoint

### DIFF
--- a/docs/FlagFix/FLAGFIX_BATCH_02_PARTIAL_CHECKPOINT_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_BATCH_02_PARTIAL_CHECKPOINT_2026-05-04.md
@@ -1,0 +1,104 @@
+# AXIS-NIDDHI — FLAGFIX Batch 02 Partial Checkpoint
+
+**Date:** 2026-05-04  
+**Status:** Checkpoint / Human review mode  
+**Scope:** Partial closure state for Batch 02 — Title and Metadata Integrity  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This checkpoint records the current partial state of Batch 02 after the initial `FLAGFIX_020` and `FLAGFIX_021` review artifacts were created.
+
+Batch 02 remains in human-review mode. This document does not authorize title correction, date correction, implementation work, rebuilds, or publication changes.
+
+---
+
+## Recorded State
+
+### FLAGFIX_020
+
+- The title comparison matrix exists.
+- The pilot was expanded.
+- A checkpoint was recorded.
+- Human review is still pending.
+- No title correction was applied.
+
+Primary artifacts:
+
+- `docs/FlagFix/FLAGFIX_020_TITLE_COMPARISON_MATRIX.md`
+- `docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_EXPANSION_PLAN_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_PILOT_CHECKPOINT_2026-05-04.md`
+- `review/title-matrix/flagfix_020_title_comparison_matrix.csv`
+
+### FLAGFIX_021
+
+- The missing date metadata audit exists.
+- The audit CSV exists.
+- A checkpoint was recorded.
+- Human review is still pending.
+- No date correction or inference was applied.
+
+Primary artifacts:
+
+- `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_REVIEW.md`
+- `docs/FlagFix/FLAGFIX_021_MISSING_DATE_REVIEW_BOX_POLICY.md`
+- `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_AUDIT_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_021_DATE_METADATA_AUDIT_CHECKPOINT_2026-05-04.md`
+- `review/date-metadata/flagfix_021_missing_date_metadata_audit.csv`
+
+---
+
+## Supporting Policies
+
+The following supporting policies remain active references for Batch 02:
+
+- `docs/FlagFix/FLAGFIX_007_TITLE_TRANSLATION_GLOSSARY_PROTECTION_POLICY.md`
+- `docs/FlagFix/FLAGFIX_011_TITLE_PUNCTUATION_PRESERVATION_POLICY.md`
+- `docs/FlagFix/FLAGFIX_012_SLUG_TITLE_DIVERGENCE_POLICY.md`
+- `docs/FlagFix/FLAGFIX_013_PT_TITLE_CAPITALIZATION_POLICY.md`
+
+These policies define review boundaries and risk categories. They do not, by themselves, authorize direct correction work.
+
+---
+
+## Global Decisions
+
+- Batch 02 remains in review/human-decision mode.
+- No automatic title correction is authorized.
+- No automatic date inference is authorized.
+- No CSL or `identity.json` edits are authorized.
+- No `SP02` or `SP11` changes are authorized.
+- No renderer or template changes are authorized.
+- No metadata operational changes are authorized.
+- No static-site output changes are authorized.
+- No rebuild/publication is authorized.
+- Any future corrections must be implemented only through targeted issues and PRs after human decisions are recorded.
+
+---
+
+## Guardrails
+
+This checkpoint does not authorize:
+
+- title correction;
+- date correction;
+- CSV expansion;
+- scripts;
+- code changes;
+- metadata changes;
+- static-site output changes;
+- rebuild/publication work.
+
+---
+
+## Next Review Gate
+
+Before any future implementation in Batch 02:
+
+1. complete human review of the current `FLAGFIX_020` matrix rows;
+2. complete human review of the current `FLAGFIX_021` audit rows;
+3. decide which cases, if any, justify targeted follow-up issues;
+4. define candidate files explicitly for each approved fix;
+5. confirm rebuild/publication impact before code work begins.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -23,6 +23,7 @@ This index is navigational only. The current directory layout is maintained by G
 | Path | Theme | Status | Observation |
 |---|---|---|---|
 | `docs/FlagFix/FLAGFIX_BATCH_02_TITLE_METADATA_INTEGRITY_PLAN.md` | Batch plan for title and metadata integrity | discussion | Groups title punctuation, slug/title divergence, protected title terms, capitalization, and date visibility review. |
+| `docs/FlagFix/FLAGFIX_BATCH_02_PARTIAL_CHECKPOINT_2026-05-04.md` | Batch 02 partial checkpoint | checkpoint | Consolidates the current 020/021 review state, supporting policies, and Batch 02 guardrails while human decisions remain pending. |
 | `docs/FlagFix/FLAGFIX_011_TITLE_PUNCTUATION_PRESERVATION_POLICY.md` | Title punctuation preservation | policy | Protects semantic punctuation such as dashes, questions, ellipses, and source-title force. |
 | `docs/FlagFix/FLAGFIX_012_SLUG_TITLE_DIVERGENCE_POLICY.md` | Slug/title divergence | policy | Prevents slug-derived titles from overriding source title semantics. |
 | `docs/FlagFix/FLAGFIX_013_PT_TITLE_CAPITALIZATION_POLICY.md` | Portuguese title capitalization | policy | Defines conservative pt-BR title casing review rules. |


### PR DESCRIPTION
## Summary

Adds a docs-only partial checkpoint for Batch 02 — Title and Metadata Integrity.

## Scope

- docs-only
- checkpoint-only
- no implementation
- no CSV changes
- no title or date correction

## Guardrails

This PR does not authorize CSL, identity.json, SP02, SP11, renderer, template, metadata, static-site output, or rebuild changes.

## Changed files

- docs/FlagFix/FLAGFIX_BATCH_02_PARTIAL_CHECKPOINT_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md