### PR TITLE
docs(flagfix): add Batch 02 closure record

### DIFF
--- a/docs/FlagFix/FLAGFIX_BATCH_02_CLOSURE_RECORD_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_BATCH_02_CLOSURE_RECORD_2026-05-04.md
@@ -1,0 +1,126 @@
+# AXIS-NIDDHI — FLAGFIX Batch 02 Closure Record
+
+**Date:** 2026-05-04  
+**Status:** Closure record / Planning and review control complete  
+**Scope:** Batch 02 — Title and Metadata Integrity  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This document records the closure state of Batch 02 as a planning and review-control batch.
+
+Batch 02 is closed in the sense that its current governance, inventory, and human-review scaffolding have been established.
+
+Batch 02 is **not** closed as a set of implemented title or metadata corrections.
+
+---
+
+## Recorded State
+
+### FLAGFIX_007
+
+- Title/glossary/Pāli protection policy exists.
+- It is covered by the `FLAGFIX_020` matrix workflow.
+- Current explicit matrix case: `TL.BB.005`.
+- No patch is authorized.
+
+### FLAGFIX_011
+
+- Title punctuation preservation policy exists.
+- It is covered by the `FLAGFIX_020` matrix workflow.
+- Current strict `punctuation_loss` case: `TL.CC.003`.
+- Related semantic punctuation case: `TL.EE.008`.
+- No patch is authorized.
+
+### FLAGFIX_012
+
+- Slug/title divergence policy exists.
+- It is covered by the `FLAGFIX_020` matrix workflow.
+- Current matrix case: `TL.BB.002`.
+- No patch is authorized.
+
+### FLAGFIX_013
+
+- pt-BR title capitalization policy exists.
+- It is covered by the `FLAGFIX_020` matrix workflow.
+- Current matrix case: `TL.CC.004`.
+- No patch is authorized.
+
+### FLAGFIX_020
+
+- The title matrix exists.
+- The pilot was expanded.
+- A checkpoint was recorded.
+- Human review is still pending.
+- No title correction was applied.
+
+### FLAGFIX_021
+
+- The missing date metadata audit exists.
+- The audit CSV exists.
+- A checkpoint was recorded.
+- Human review is still pending.
+- No date correction or inference was applied.
+
+---
+
+## Primary Artifacts
+
+- `docs/FlagFix/FLAGFIX_BATCH_02_TITLE_METADATA_INTEGRITY_PLAN.md`
+- `docs/FlagFix/FLAGFIX_BATCH_02_PARTIAL_CHECKPOINT_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_020_TITLE_COMPARISON_MATRIX.md`
+- `docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_EXPANSION_PLAN_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_PILOT_CHECKPOINT_2026-05-04.md`
+- `review/title-matrix/flagfix_020_title_comparison_matrix.csv`
+- `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_REVIEW.md`
+- `docs/FlagFix/FLAGFIX_021_MISSING_DATE_REVIEW_BOX_POLICY.md`
+- `docs/FlagFix/FLAGFIX_021_MISSING_DATE_METADATA_AUDIT_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_021_DATE_METADATA_AUDIT_CHECKPOINT_2026-05-04.md`
+- `review/date-metadata/flagfix_021_missing_date_metadata_audit.csv`
+
+---
+
+## Global Decision
+
+Batch 02 is closed as a planning/review-control batch, not as implemented corrections.
+
+Future title or date corrections require:
+
+- explicit human decisions;
+- targeted issues;
+- targeted branches and PRs;
+- explicitly scoped changed files;
+- rollback planning before implementation.
+
+No CSL, `identity.json`, `SP02`, `SP11`, renderer, template, metadata, static-site output, or rebuild work is authorized by this closure record.
+
+---
+
+## Guardrails
+
+This closure record does not authorize:
+
+- title correction;
+- date correction;
+- glossary correction;
+- slug correction;
+- CSV expansion;
+- scripts;
+- code changes;
+- metadata changes;
+- static-site output changes;
+- rebuild/publication work.
+
+---
+
+## Final Batch 02 Posture
+
+Batch 02 should now be treated as:
+
+- documented;
+- inventoried;
+- policy-framed;
+- paused for human review;
+- ready for targeted downstream implementation only after explicit decisions.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -24,6 +24,7 @@ This index is navigational only. The current directory layout is maintained by G
 |---|---|---|---|
 | `docs/FlagFix/FLAGFIX_BATCH_02_TITLE_METADATA_INTEGRITY_PLAN.md` | Batch plan for title and metadata integrity | discussion | Groups title punctuation, slug/title divergence, protected title terms, capitalization, and date visibility review. |
 | `docs/FlagFix/FLAGFIX_BATCH_02_PARTIAL_CHECKPOINT_2026-05-04.md` | Batch 02 partial checkpoint | checkpoint | Consolidates the current 020/021 review state, supporting policies, and Batch 02 guardrails while human decisions remain pending. |
+| `docs/FlagFix/FLAGFIX_BATCH_02_CLOSURE_RECORD_2026-05-04.md` | Batch 02 closure record | checkpoint | Closes Batch 02 as a planning/review-control batch and records that 007/011/012/013 are covered by the 020 matrix workflow while 020/021 remain paused for human review. |
 | `docs/FlagFix/FLAGFIX_011_TITLE_PUNCTUATION_PRESERVATION_POLICY.md` | Title punctuation preservation | policy | Protects semantic punctuation such as dashes, questions, ellipses, and source-title force. |
 | `docs/FlagFix/FLAGFIX_012_SLUG_TITLE_DIVERGENCE_POLICY.md` | Slug/title divergence | policy | Prevents slug-derived titles from overriding source title semantics. |
 | `docs/FlagFix/FLAGFIX_013_PT_TITLE_CAPITALIZATION_POLICY.md` | Portuguese title capitalization | policy | Defines conservative pt-BR title casing review rules. |


### PR DESCRIPTION
## Summary

Adds a docs-only closure record for Batch 02 — Title and Metadata Integrity.

## Scope

- docs-only
- checkpoint/closure-only
- no implementation
- no CSV changes
- no title/date/glossary/slug correction

## Guardrails

This PR does not authorize CSL, identity.json, SP02, SP11, renderer, template, metadata, static-site output, or rebuild changes.

## Changed files

- docs/FlagFix/FLAGFIX_BATCH_02_CLOSURE_RECORD_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md