### PR TITLE
docs(flagfix): add Batch 03 closure record

### DIFF
--- a/docs/FlagFix/FLAGFIX_BATCH_03_CLOSURE_RECORD_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_BATCH_03_CLOSURE_RECORD_2026-05-04.md
@@ -1,0 +1,105 @@
+# AXIS-NIDDHI — FLAGFIX Batch 03 Closure Record
+
+**Date:** 2026-05-04  
+**Status:** Closure record / Inventory and review control complete  
+**Scope:** Batch 03 — Pāli Protection  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This document records the closure state of Batch 03 as an inventory and review-control batch.
+
+Batch 03 is closed in the sense that its policy framing and initial read-only audit artifacts now exist.
+
+Batch 03 is **not** closed as a set of implemented functional protections.
+
+---
+
+## Recorded State
+
+Audit artifacts now exist:
+
+- `docs/FlagFix/FLAGFIX_BATCH_03_PALI_PROTECTION_AUDIT_2026-05-04.md`
+- `review/pali-protection/flagfix_batch03_pali_protection_audit.csv`
+
+### FLAGFIX_002
+
+- Pāli term color/audio taxonomy
+- Partially operational in `main`
+- Requires continued review/inventory before any future adjustments
+- No new patch is authorized
+
+### FLAGFIX_003
+
+- Pāli grammar, diacritics, and orthography
+- Policy/inventory pending
+- Audit pilot now exists
+- No patch is authorized
+
+### FLAGFIX_004
+
+- Pāli quote protection
+- Policy/inventory pending
+- Audit pilot now exists
+- No patch is authorized
+
+### FLAGFIX_009
+
+- Miccha / Micchā Diṭṭhi glossary protection
+- Policy/inventory pending
+- Audit pilot now exists
+- No patch is authorized
+
+### FLAGFIX_007
+
+- Already integrated with the Batch 02 / `FLAGFIX_020` title-review workflow
+- No parallel Batch 03 implementation track should be opened from this closure record
+
+---
+
+## Global Decision
+
+Batch 03 remains human-review-first.
+
+Any future changes require:
+
+- targeted issues;
+- targeted branches and PRs;
+- explicit review decisions;
+- exact changed-file scope;
+- rollback planning before implementation.
+
+No CSL, renderer, JavaScript, CSS, glossary pipeline, metadata, static-site output, or rebuild work is authorized by this closure record.
+
+---
+
+## Guardrails
+
+This closure record does not authorize:
+
+- CSS changes;
+- JavaScript changes;
+- renderer changes;
+- CSL changes;
+- glossary pipeline changes;
+- metadata changes;
+- template changes;
+- static-site output changes;
+- rebuild/publication;
+- title correction;
+- glossary correction;
+- Pāli normalization.
+
+---
+
+## Final Batch 03 Posture
+
+Batch 03 should now be treated as:
+
+- documented;
+- inventoried at pilot level;
+- policy-framed;
+- paused for human review;
+- ready for targeted downstream implementation only after explicit decisions.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -44,6 +44,7 @@ This index is navigational only. The current directory layout is maintained by G
 |---|---|---|---|
 | `docs/FlagFix/FLAGFIX_BATCH_03_PALI_PROTECTION_PLAN.md` | Batch plan for Pāli and protected terminology | discussion | Groups protected terms, diacritics, Pāli quotes, glossary behavior, and title protection. |
 | `docs/FlagFix/FLAGFIX_BATCH_03_PALI_PROTECTION_AUDIT_2026-05-04.md` | Batch 03 Pāli protection audit | checkpoint | Pilot read-only inventory of glossary/audio term markers, quote preservation, diacritic drift, and Miccha/Micchā title/body evidence; no implementation is authorized here. |
+| `docs/FlagFix/FLAGFIX_BATCH_03_CLOSURE_RECORD_2026-05-04.md` | Batch 03 closure record | checkpoint | Closes Batch 03 as an inventory/review-control batch, records the audit artifacts, and keeps 002/003/004/009 in human-review-first posture with no new patches authorized. |
 | `docs/FlagFix/FLAGFIX_002_PALI_TERM_COLOR_AUDIO_TAXONOMY_POLICY.md` | Pāli term color and audio taxonomy | policy | Preserves visible distinctions between glossary-only, audio-linked, and uncertain Pāli terms. |
 | `docs/FlagFix/FLAGFIX_003_PALI_GRAMMAR_DIACRITICS_ORTHOGRAPHY_POLICY.md` | Pāli grammar, diacritics, and orthography | policy | Requires human review for spelling, macrons, grammar, and source-convention questions. |
 | `docs/FlagFix/FLAGFIX_004_PALI_QUOTE_PROTECTION_POLICY.md` | Pāli quote protection | policy | Protects Pāli quotes and canonical phrases from translation-stage mutation. |


### PR DESCRIPTION
## Summary

Adds a docs-only closure record for Batch 03 — Pali Protection.

## Scope

- docs-only
- closure/checkpoint-only
- no implementation
- no CSV changes
- no CSS, JS, renderer, CSL, template, metadata, pipeline, static-site output, or rebuild changes

## Guardrails

This PR does not authorize functional patches, glossary pipeline changes, Pali normalization, or rebuild/publication.

## Changed files

- docs/FlagFix/FLAGFIX_BATCH_03_CLOSURE_RECORD_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md