### PR TITLE
docs(flagfix): add Batch 04 closure record

### DIFF
--- a/docs/FlagFix/FLAGFIX_BATCH_04_CLOSURE_RECORD_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_BATCH_04_CLOSURE_RECORD_2026-05-04.md
@@ -1,0 +1,140 @@
+# AXIS-NIDDHI — FLAGFIX Batch 04 Closure Record
+
+**Date:** 2026-05-04  
+**Status:** Closure record / Audit, inventory, and review control complete  
+**Scope:** Batch 04 — Media and Assets  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This document records the closure state of Batch 04 as an audit, inventory, and review-control batch.
+
+Batch 04 is closed in the sense that its current policy framing, audit posture, and future implementation boundaries have been documented.
+
+Batch 04 is **not** closed as a set of implemented media, image, audio, video, or asset-handling fixes.
+
+---
+
+## Recorded State
+
+Batch 04 audit artifacts now exist:
+
+- `docs/FlagFix/FLAGFIX_BATCH_04_MEDIA_ASSETS_AUDIT_2026-05-04.md`
+- `review/media-assets/flagfix_batch04_media_assets_audit.csv`
+
+### FLAGFIX_005
+
+- Translatable image / flowchart assets
+- Remains a future subfront
+- Still requires per-asset review inventory and explicit human decisions
+- No implementation is authorized
+
+### FLAGFIX_010
+
+- Audio offline placeholders and external resolution
+- Remains a future subfront
+- Still requires traceability-first review of placeholder states and external audio behavior
+- No implementation is authorized
+
+### FLAGFIX_014
+
+- Image rendering size / centering / zoom
+- Must remain split-friendly
+- Should not be treated as one global patch
+- No implementation is authorized
+
+### FLAGFIX_015
+
+- YouTube print markers
+- Remains a future subfront
+- Still requires selector/variant audit before any patch
+- No implementation is authorized
+
+### FLAGFIX_022
+
+- Already continues in its own dedicated package
+- Existing records include:
+  - audit
+  - `022A` hardening plan
+  - `022B` markup normalization plan
+  - hardening roadmap
+- This closure does not reopen or duplicate that package
+
+---
+
+## Primary Records
+
+- `docs/FlagFix/FLAGFIX_BATCH_04_MEDIA_ASSETS_PLAN.md`
+- `docs/FlagFix/FLAGFIX_BATCH_04_MEDIA_ASSETS_AUDIT_2026-05-04.md`
+- `review/media-assets/flagfix_batch04_media_assets_audit.csv`
+- `docs/FlagFix/FLAGFIX_005_TRANSLATABLE_IMAGE_FLOWCHART_ASSETS_POLICY.md`
+- `docs/FlagFix/FLAGFIX_010_AUDIO_OFFLINE_PLACEHOLDER_POLICY.md`
+- `docs/FlagFix/FLAGFIX_014_IMAGE_RENDERING_SIZE_CENTERING_ZOOM_POLICY.md`
+- `docs/FlagFix/FLAGFIX_015_YOUTUBE_PRINT_MARKER_POLICY.md`
+- `docs/FlagFix/FLAGFIX_022_SHORTCODE_WORDPRESS_EASY_MEDIA_DOWNLOAD.md`
+- `docs/FlagFix/FLAGFIX_022_MEDIA_EVIDENCE_AUDIT_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_022A_CORRUPTED_URL_HARDENING_PLAN_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_022B_MEDIA_EVIDENCE_MARKUP_PLAN_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_022_HARDENING_ROADMAP_2026-05-04.md`
+
+---
+
+## Global Decision
+
+Batch 04 is closed as an `audit / inventory / review-control` batch.
+
+No implementation has been globally authorized from this batch.
+
+Each future subfront must proceed through its own:
+
+- issue;
+- branch;
+- PR;
+- minimum viable diff;
+- local/visual test plan;
+- rollback plan.
+
+If any future work touches `pipeline/13-static-site/` or other generated publication output, it also requires explicit publication/static-site approval.
+
+---
+
+## Guardrails
+
+This closure record does not authorize:
+
+- CSS changes;
+- JavaScript changes;
+- renderer changes;
+- CSL changes;
+- template changes;
+- metadata operational changes;
+- pipeline changes;
+- static-site output changes;
+- rebuild/publication;
+- deploy/config changes;
+- global image rendering patch;
+- global audio placeholder patch;
+- global YouTube marker patch.
+
+---
+
+## Recommended Next Step
+
+The next safe direction after Batch 04 is either:
+
+1. Batch 05 — Architecture / Study Order, or
+2. a global sanity checkpoint for the FlagFix sprint before opening new implementation tracks.
+
+---
+
+## Final Batch 04 Posture
+
+Batch 04 should now be treated as:
+
+- documented;
+- audited at pilot level;
+- inventory-controlled;
+- not yet implementation-ready;
+- ready for narrowly scoped downstream work only after explicit approval.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -58,6 +58,7 @@ This index is navigational only. The current directory layout is maintained by G
 |---|---|---|---|
 | `docs/FlagFix/FLAGFIX_BATCH_04_MEDIA_ASSETS_PLAN.md` | Batch plan for media and assets | discussion | Groups image, audio, YouTube, and asset traceability issues. |
 | `docs/FlagFix/FLAGFIX_BATCH_04_MEDIA_ASSETS_AUDIT_2026-05-04.md` | Batch 04 media and assets audit | checkpoint | Pilot read-only inventory of text-bearing images, diagrams, YouTube/embed variants, audio traceability, and media-evidence cross-references; no implementation is authorized here. |
+| `docs/FlagFix/FLAGFIX_BATCH_04_CLOSURE_RECORD_2026-05-04.md` | Batch 04 closure record | checkpoint | Closes Batch 04 as an audit/inventory/review-control batch, keeps 014 split-friendly, and records that 022 remains in its own dedicated hardening package. |
 | `docs/FlagFix/FLAGFIX_005_TRANSLATABLE_IMAGE_FLOWCHART_ASSETS_POLICY.md` | Translatable image and flowchart assets | policy | Preserves original media as evidence before any human redraw or translation. |
 | `docs/FlagFix/FLAGFIX_010_AUDIO_OFFLINE_PLACEHOLDER_POLICY.md` | Audio placeholders and external resolution | policy | Requires language-aware, traceable audio fallback states. |
 | `docs/FlagFix/FLAGFIX_014_IMAGE_RENDERING_SIZE_CENTERING_ZOOM_POLICY.md` | Image rendering size, centering, and zoom | policy | Frames future image readability work without authorizing renderer or CSS changes. |


### PR DESCRIPTION
## Summary

Adds a docs-only closure record for Batch 04 — Media and Assets.

## Scope

- docs-only
- closure/checkpoint-only
- no implementation
- no CSV changes
- no CSS, JS, renderer, CSL, template, metadata, pipeline, static-site output, rebuild, or deploy/config changes

## Guardrails

This PR closes Batch 04 as audit/inventory/review-control only. It does not authorize functional patches. FLAGFIX_014 remains split-friendly and FLAGFIX_022 remains in its own dedicated hardening package.

## Changed files

- docs/FlagFix/FLAGFIX_BATCH_04_CLOSURE_RECORD_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md