### PR TITLE
docs(flagfix): add global sanity checkpoint after Batch 04

### DIFF
--- a/docs/FlagFix/FLAGFIX_GLOBAL_SANITY_CHECKPOINT_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_GLOBAL_SANITY_CHECKPOINT_2026-05-04.md
@@ -1,0 +1,124 @@
+# AXIS-NIDDHI -- FlagFix Global Sanity Checkpoint
+
+**Date:** 2026-05-04  
+**Status:** Checkpoint / Docs-only sanity record  
+**Scope:** Sprint-wide status through Batch 04 closure  
+**Current HEAD at recording:** `7ee9fc7`  
+**Latest merged PR state at recording:** PR #107 merged after PR #106  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This document records a global sanity checkpoint for the FlagFix sprint after Batch 04 closure.
+
+It summarizes what has been implemented, what has only been documented or audited, and which review-control boundaries remain in force before any future implementation work.
+
+This checkpoint is docs-only. It does not authorize new functional changes.
+
+---
+
+## Current Sprint State
+
+The FlagFix sprint is currently coherent through Batch 04:
+
+- Batch 01 is closed as an operational print-review batch with selected implemented fixes.
+- Batch 02 is closed as a planning/review-control batch with human-review workflows in place.
+- Batch 03 is closed as an inventory/review-control batch with Pali protection audit artifacts recorded.
+- Batch 04 is closed as an audit/inventory/review-control batch with media and assets review artifacts recorded.
+
+Closure records exist for all four completed batches:
+
+- `docs/FlagFix/FLAGFIX_BATCH_01_CLOSURE_RECORD_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_BATCH_02_CLOSURE_RECORD_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_BATCH_03_CLOSURE_RECORD_2026-05-04.md`
+- `docs/FlagFix/FLAGFIX_BATCH_04_CLOSURE_RECORD_2026-05-04.md`
+
+---
+
+## Implemented Functional Changes
+
+The following functional changes were implemented earlier in the sprint and are already tracked by their own records:
+
+### FLAGFIX_025
+
+Print oversized image overflow was constrained so large figures do not force print shrink-to-fit geometry shifts or unstable review column behavior.
+
+### FLAGFIX_017
+
+The accidental `#reading-progress` leak into print/PDF output was removed so the reading progress bar no longer appears in printed review artifacts.
+
+### FLAGFIX_024
+
+Print `h5` review heading styling was standardized for review/PDF use while preserving the online collapsible behavior of those headings.
+
+These implemented fixes remain the only explicitly completed functional FlagFix items recorded through Batch 04 closure.
+
+---
+
+## Docs and Review-Control Work Completed
+
+The sprint also completed a substantial documentation, audit, and review-control layer without authorizing new implementation:
+
+- FlagFix docs were reorganized and consolidated under `docs/FlagFix/`.
+- Legacy ToDoList imports were brought into the FlagFix records and indexed.
+- `FLAGFIX_020` now has a title matrix workflow, pilot expansion, and checkpoint with human review pending.
+- `FLAGFIX_021` now has a missing date metadata audit, CSV subset, and checkpoint with human review pending.
+- `FLAGFIX_022` now has its own triage package, media evidence audit, `022A` hardening plan, `022B` markup normalization plan, and hardening roadmap.
+- Batch 03 now has a Pali protection audit:
+  - `docs/FlagFix/FLAGFIX_BATCH_03_PALI_PROTECTION_AUDIT_2026-05-04.md`
+  - `review/pali-protection/flagfix_batch03_pali_protection_audit.csv`
+- Batch 04 now has a media and assets audit:
+  - `docs/FlagFix/FLAGFIX_BATCH_04_MEDIA_ASSETS_AUDIT_2026-05-04.md`
+  - `review/media-assets/flagfix_batch04_media_assets_audit.csv`
+
+This means the sprint now has structured closure for:
+
+- implemented print-review fixes where narrowly approved;
+- title/date review-control workflows where human decisions are still pending;
+- media and Pali preservation audits where implementation has not yet been approved.
+
+---
+
+## Authorization Boundary
+
+No new implementation is authorized by this checkpoint.
+
+This checkpoint does not authorize changes to:
+
+- renderer;
+- CSL;
+- HTML;
+- CSS;
+- JavaScript;
+- pipeline;
+- metadata;
+- navigation;
+- deployment configuration;
+- Cloudflare configuration;
+- GitHub Actions;
+- static-site output.
+
+Batch 05 work or any future implementation work must begin in a new issue, a new branch, and a new PR with explicit scope and expected changed files.
+
+---
+
+## Rollback Posture
+
+This is a docs-only checkpoint.
+
+If it ever needs to be reverted, it can be cleanly reverted by one commit without affecting functional output.
+
+---
+
+## Next Recommended Gate
+
+The next recommended gate is one of the following:
+
+1. Batch 05 planning, if the goal is to continue the sprint at the architecture/study-order level without authorizing implementation.
+2. A narrowly scoped implementation issue taken from an existing roadmap or audit package, if the goal is to begin approved functional follow-up work.
+
+Good candidates for future implementation-specific gates already exist in the current records, especially where audit and roadmap material is already in place.
+
+Until a new gate is explicitly approved, the current sprint state should be treated as stable review-control documentation rather than authorization for further production changes.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -86,6 +86,7 @@ This index is navigational only. The current directory layout is maintained by G
 | Path | Theme | Status | Observation |
 |---|---|---|---|
 | `docs/FlagFix/FLAGFIX_023_PRODUCTION_BUILD_INPUT_CONTRACT.md` | Production build input contract | policy | Architecture guardrail for rebuild assumptions, CSL presence, and publication-repo boundaries. |
+| `docs/FlagFix/FLAGFIX_GLOBAL_SANITY_CHECKPOINT_2026-05-04.md` | Global sanity checkpoint after Batch 04 | checkpoint | Sprint-wide checkpoint through Batch 04 closure, summarizing implemented fixes versus docs/review-control work and authorizing no new implementation. |
 | `docs/FlagFix/PRINT_REVIEW_LINKS_V1_LEGACY_REVIEW_2026-05-04.md` | Legacy print review links branch assessment | review scaffold | Reviews `print-review-links-v1` as reference only; does not authorize merge, cherry-pick, or implementation. |
 | `docs/FlagFix/FLAGFIX_STATUS_CHECKPOINT_2026-05-02.md` | FlagFix status snapshot | checkpoint | Captures repository state and open issue groups after issue migration and early batch planning. |
 | `docs/FlagFix/AXIS_HANDOFF_FLAGFIX_SPRINT_2026-05-03.md` | Post-sprint handoff | checkpoint | Records the final state of the policy/review-scaffold sprint completed around 2026-05-03 / 2026-05-04 UTC. |


### PR DESCRIPTION
## Summary

Adds a docs-only global sanity checkpoint after Batch 04 closure.

## Scope

- docs-only
- global checkpoint only
- no implementation

## Guardrails

This PR does not authorize changes to renderer, CSL, HTML, CSS, JS, pipeline, metadata, navigation, deployment config, Cloudflare config, GitHub Actions, or static-site output.

## Changed files

- docs/FlagFix/FLAGFIX_GLOBAL_SANITY_CHECKPOINT_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md

## Rollback

This docs-only checkpoint can be reverted by one commit.

## Next Gate

Batch 05 planning or a separately approved implementation-specific issue/branch/PR from existing roadmaps.