### PR TITLE
docs(flagfix): add Batch 05 architecture checkpoint

### DIFF
--- a/docs/FlagFix/FLAGFIX_BATCH_05_ARCHITECTURE_CHECKPOINT_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_BATCH_05_ARCHITECTURE_CHECKPOINT_2026-05-04.md
@@ -1,0 +1,141 @@
+# AXIS-NIDDHI -- FlagFix Batch 05 Architecture Checkpoint
+
+**Date:** 2026-05-04  
+**Status:** Checkpoint / Docs-only architecture record  
+**Scope:** Batch 05 architecture and study-order boundary  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This checkpoint records the current architecture-only state of FlagFix Batch 05 after Batches 01 through 04 were closed as implemented, review-control, inventory, or audit packages as appropriate.
+
+Batch 05 is the next planning frontier, but it is not an implementation batch yet.
+
+---
+
+## Batch 05 Scope
+
+This batch currently groups the following FlagFix records:
+
+- `FLAGFIX_000` -- AXIS preservation strategy
+- `FLAGFIX_001` -- future preservation layers
+- `FLAGFIX_008` -- canonical study order and path registry policy
+- `FLAGFIX_008B` -- AXIS-Cosmos order graph discussion
+
+Together, these records define architecture boundaries for future study-order, pathway, graph, and preservation-layer work.
+
+---
+
+## Current Classification
+
+Batch 05 is currently:
+
+- architecture/planning boundary only;
+- not implementation-ready;
+- not audit inventory yet;
+- not authorized to change production behavior.
+
+This batch exists to define safe boundaries before any registry, path, graph, or study-order feature work is attempted.
+
+---
+
+## AXIS-Cosmos Classification
+
+AXIS-Cosmos is currently classified as:
+
+- architecture discussion;
+- future feature concept;
+- not policy by itself;
+- not approved implementation.
+
+The current repository state only documents AXIS-Cosmos conceptually. It does not authorize graph artifacts, recommendation engines, path generation, or UI integration.
+
+---
+
+## Current Repo State
+
+Within Batch 05, the repository currently contains:
+
+- policy documents establishing preservation and pathway guardrails;
+- a batch plan separating architecture, archive order, and study order;
+- a discussion document for AXIS-Cosmos and future graph-like layers.
+
+The repository does **not** currently contain an approved implementation in this batch for:
+
+- study-order registry files;
+- graph schema files;
+- graph JSON artifacts;
+- Cosmos/Navigator UI integration;
+- publication-layer study-order behavior;
+- deployment-approved architecture output.
+
+In other words, Batch 05 has boundary documentation, but no approved operational implementation.
+
+---
+
+## Future Gates Before Implementation
+
+Before any implementation work in this batch, the following gates should exist as separate approved issues or PRs:
+
+1. registry schema gate;
+2. canonical-vs-study-order boundary gate;
+3. graph artifact format gate;
+4. UI/Navigator integration gate;
+5. publication/deploy approval gate;
+6. rollback/checkpoint gate.
+
+These gates are needed so future architecture work remains explicit, reversible, and reviewable.
+
+---
+
+## Explicit No-Action Rules
+
+This checkpoint does not authorize:
+
+- creating graph artifacts;
+- creating a study-order registry;
+- modifying the static site;
+- altering canonical order;
+- altering navigation behavior;
+- altering renderer behavior;
+- altering templates;
+- altering pipeline behavior.
+
+It also does not authorize changes to:
+
+- renderer;
+- CSL;
+- HTML;
+- CSS;
+- JavaScript;
+- templates;
+- pipeline;
+- metadata;
+- navigation;
+- deployment configuration;
+- Cloudflare configuration;
+- GitHub Actions;
+- static-site output;
+- graph artifacts;
+- study-order registry files;
+- Navigator/Cosmos implementation files.
+
+---
+
+## Recommended Next Future Work
+
+The recommended next step, if approved later, is a separate docs-only registry schema proposal for Batch 05.
+
+That future proposal should remain architecture-first and should not implement registry artifacts, graph outputs, or UI behavior in the same PR.
+
+No implementation is authorized by this checkpoint.
+
+---
+
+## Closure Posture
+
+Batch 05 is now documented as an architecture checkpoint candidate rather than an active implementation track.
+
+Any future work in this batch must begin with a new issue, a new branch, a new PR, and explicit scope boundaries before any registry, graph, study-order, Navigator, deployment, or publication behavior is touched.

--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -76,6 +76,7 @@ This index is navigational only. The current directory layout is maintained by G
 | Path | Theme | Status | Observation |
 |---|---|---|---|
 | `docs/FlagFix/FLAGFIX_BATCH_05_ARCHITECTURE_STUDY_ORDER_PLAN.md` | Batch plan for architecture and study order | discussion | Separates corpus order, archive order, review order, and future study paths. |
+| `docs/FlagFix/FLAGFIX_BATCH_05_ARCHITECTURE_CHECKPOINT_2026-05-04.md` | Batch 05 architecture checkpoint | checkpoint | Records Batch 05 as architecture/planning boundary only, confirms AXIS-Cosmos is still discussion-stage, and authorizes no registry, graph, UI, or production implementation. |
 | `docs/FlagFix/FLAGFIX_000_AXIS_PRESERVATION_STRATEGY_POLICY.md` | AXIS preservation strategy | policy | Defines source traceability, canonical identity, reproducibility, and review boundaries. |
 | `docs/FlagFix/FLAGFIX_001_FUTURE_PRESERVATION_LAYERS_POLICY.md` | Future preservation layers | policy | Describes future layers without authorizing implementation in production. |
 | `docs/FlagFix/FLAGFIX_008_CANONICAL_STUDY_ORDER_PATH_REGISTRY_POLICY.md` | Canonical study order and path registry | policy | Requires explicit, auditable path registries instead of overwriting source order. |


### PR DESCRIPTION
## Summary

Adds a docs-only architecture checkpoint for FlagFix Batch 05.

## Scope

- docs-only
- architecture checkpoint only
- no implementation

## Guardrails

This PR does not authorize changes to renderer, CSL, HTML, CSS, JS, templates, pipeline, metadata, navigation, deployment config, Cloudflare config, GitHub Actions, static-site output, graph artifacts, or study-order registry files.

## Changed files

- docs/FlagFix/FLAGFIX_BATCH_05_ARCHITECTURE_CHECKPOINT_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md

## Notes

Batch 05 remains architecture/planning boundary only. AXIS-Cosmos remains discussion-stage and no implementation is authorized by this PR.