### PR TITLE
docs(flagfix): add sprint final closure record

### DIFF
--- a/docs/FlagFix/FLAGFIX_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_INDEX.md
@@ -88,6 +88,7 @@ This index is navigational only. The current directory layout is maintained by G
 |---|---|---|---|
 | `docs/FlagFix/FLAGFIX_023_PRODUCTION_BUILD_INPUT_CONTRACT.md` | Production build input contract | policy | Architecture guardrail for rebuild assumptions, CSL presence, and publication-repo boundaries. |
 | `docs/FlagFix/FLAGFIX_GLOBAL_SANITY_CHECKPOINT_2026-05-04.md` | Global sanity checkpoint after Batch 04 | checkpoint | Sprint-wide checkpoint through Batch 04 closure, summarizing implemented fixes versus docs/review-control work and authorizing no new implementation. |
+| `docs/FlagFix/FLAGFIX_SPRINT_FINAL_CLOSURE_RECORD_2026-05-04.md` | Final FlagFix sprint closure record | checkpoint | Summarizes the completed sprint through Batch 05 checkpoint, records implemented fixes and review-control artifacts, and authorizes no new implementation. |
 | `docs/FlagFix/PRINT_REVIEW_LINKS_V1_LEGACY_REVIEW_2026-05-04.md` | Legacy print review links branch assessment | review scaffold | Reviews `print-review-links-v1` as reference only; does not authorize merge, cherry-pick, or implementation. |
 | `docs/FlagFix/FLAGFIX_STATUS_CHECKPOINT_2026-05-02.md` | FlagFix status snapshot | checkpoint | Captures repository state and open issue groups after issue migration and early batch planning. |
 | `docs/FlagFix/AXIS_HANDOFF_FLAGFIX_SPRINT_2026-05-03.md` | Post-sprint handoff | checkpoint | Records the final state of the policy/review-scaffold sprint completed around 2026-05-03 / 2026-05-04 UTC. |

--- a/docs/FlagFix/FLAGFIX_SPRINT_FINAL_CLOSURE_RECORD_2026-05-04.md
+++ b/docs/FlagFix/FLAGFIX_SPRINT_FINAL_CLOSURE_RECORD_2026-05-04.md
@@ -1,0 +1,167 @@
+# AXIS-NIDDHI -- FlagFix Sprint Final Closure Record
+
+**Date:** 2026-05-04  
+**Status:** Final closure record / Docs-only  
+**Scope:** FlagFix sprint through Batch 05 checkpoint  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This document records the final docs-only closure state of the FlagFix sprint after the completion, closure, checkpointing, or audit framing of Batches 01 through 05.
+
+It summarizes what was implemented, what was operationally resolved without new patches, what was documented as review-control work, and what remains explicitly blocked pending future scoped issues and approvals.
+
+---
+
+## Sprint Scope
+
+During this sprint:
+
+- FlagFix records were reorganized into `docs/FlagFix/`.
+- Legacy ToDoList records were imported and indexed into the FlagFix documentation set.
+- Batches 01 through 05 were triaged, documented, audited, checkpointed, or closed according to their appropriate scope.
+
+The sprint produced a structured documentation layer around:
+
+- implemented print-review hotfixes;
+- review-control title and metadata workflows;
+- Pali protection inventory;
+- media and assets audit framing;
+- architecture and study-order boundary planning.
+
+---
+
+## Implemented Functional Fixes
+
+The following functional FlagFix items were implemented during the sprint:
+
+### FLAGFIX_025
+
+Oversized print images were constrained so wide figures no longer force unstable shrink-to-fit print geometry.
+
+### FLAGFIX_017
+
+The reading progress bar was hidden from print/PDF output, removing accidental leakage of `#reading-progress` into review exports.
+
+### FLAGFIX_024
+
+Print `h5` review heading styling was standardized while preserving the online collapsible behavior of those headings.
+
+These remain the main explicitly implemented functional fixes produced by the sprint.
+
+---
+
+## Operationally Resolved or No-Action Closures
+
+The following items were closed or operationally resolved without opening broader new implementation scope:
+
+- `FLAGFIX_016`
+- `FLAGFIX_018`
+- `FLAGFIX_006`
+- `FLAGFIX_019`
+- Batch 01 closure as a whole
+
+Their current posture is:
+
+- either neutralized by current print hiding behavior;
+- or acceptable after related fixes;
+- or intentionally deferred as future polish rather than active defects.
+
+---
+
+## Review, Audit, and Control Artifacts Created
+
+The sprint also created the following non-implementation artifacts:
+
+- `FLAGFIX_020` title matrix plan, pilot expansion, and checkpoint
+- `FLAGFIX_021` date metadata audit and checkpoint
+- Batch 03 Pali protection audit and closure
+- Batch 04 media assets audit and closure
+- Batch 05 architecture checkpoint
+
+These records established human-review workflows, audit trails, and architecture boundaries without authorizing code, metadata, or publication-layer changes.
+
+---
+
+## FLAGFIX_022 Package State
+
+The `FLAGFIX_022` package now has a dedicated hardening track:
+
+- the original visible shortcode leak is operationally resolved for readers;
+- the media evidence audit is recorded;
+- `022A` corrupted URL hardening plan is recorded;
+- `022B` media evidence markup normalization plan is recorded;
+- a hardening roadmap is recorded.
+
+Future implementation for `FLAGFIX_022` requires:
+
+- dedicated issues;
+- dedicated branches and PRs;
+- explicit implementation scope;
+- explicit rebuild/static-site approval if publication output is touched.
+
+This final closure record does not reopen `FLAGFIX_022` for implementation.
+
+---
+
+## Current Invariant After Sprint
+
+At the end of the sprint, the intended invariant is:
+
+- `main` is kept clean and checkpointed at each approved phase;
+- no lab directories were touched as part of these production-repo changes;
+- no manual CSL or corpus rewrite was performed;
+- no uncontrolled static-site rebuild was performed;
+- Cloudflare-triggering docs or production-facing changes were handled consciously and documented with checkpoints/PRs;
+- future work must start from a dedicated issue, branch, and PR.
+
+The sprint therefore ends with tighter review control, clearer architecture boundaries, and narrower future change surfaces.
+
+---
+
+## Guardrails
+
+This final closure record does not authorize:
+
+- code changes;
+- CSS changes;
+- JavaScript changes;
+- renderer changes;
+- template changes;
+- CSL changes;
+- metadata changes;
+- navigation changes;
+- pipeline changes;
+- static-site output changes;
+- deployment configuration changes;
+- Cloudflare configuration changes;
+- GitHub Actions changes;
+- rebuild/publication work.
+
+It also does not authorize ad hoc continuation of the sprint without a newly scoped review gate.
+
+---
+
+## Recommended Next Phase
+
+Do not continue patching ad hoc.
+
+Open a new sprint or follow-up track only after selecting one narrow target such as:
+
+1. `FLAGFIX_022A` implementation planning;
+2. `FLAGFIX_022B` implementation planning;
+3. title matrix expansion;
+4. deeper date metadata audit;
+5. AXIS-Cosmos / Navigator architecture, docs-only.
+
+Any next phase must begin from a dedicated issue, branch, PR, explicit test posture, and explicit rollback posture.
+
+---
+
+## Rollback Posture
+
+This is a docs-only final closure record.
+
+If necessary, it can be reverted cleanly by one commit without affecting production behavior.


### PR DESCRIPTION
## Summary

Adds a docs-only final closure record for the completed FlagFix sprint.

## Scope

- docs/FlagFix only
- final closure record
- no implementation

## Guardrails

This PR does not authorize code, CSS, JS, pipeline, renderer, templates, CSL, metadata, navigation, static-site output, deploy config, Cloudflare config, GitHub Actions, or rebuild work.

## Changed files

- docs/FlagFix/FLAGFIX_SPRINT_FINAL_CLOSURE_RECORD_2026-05-04.md
- docs/FlagFix/FLAGFIX_INDEX.md

## Notes

The closure record summarizes implemented fixes, operationally resolved items, review-control artifacts, the FLAGFIX_022 package state, current post-sprint invariants, and recommended narrow next-phase gates.