### PR TITLE
docs: add post-FlagFix handoff

### DIFF
--- a/docs/AXIS_NIDDHI_POST_FLAGFIX_HANDOFF_2026-05-09.md
+++ b/docs/AXIS_NIDDHI_POST_FLAGFIX_HANDOFF_2026-05-09.md
@@ -1,0 +1,133 @@
+# AXIS-NIDDHI -- Post-FlagFix Handoff
+
+**Date:** 2026-05-09  
+**Status:** Informational handoff / Docs-only  
+**Scope:** Post-FlagFix stabilization and next-step planning  
+**Implementation:** Not authorized by this document
+
+---
+
+## Purpose
+
+This document records the post-FlagFix handoff state for AXIS-NIDDHI after the FlagFix sprint was fully documented, checkpointed, and closed through Batch 05 architecture planning.
+
+It exists to help the next sprint begin from a stable planning baseline rather than from ad hoc patching.
+
+---
+
+## Final State of the FlagFix Sprint
+
+The FlagFix sprint ended with:
+
+- FlagFix records reorganized under `docs/FlagFix/`;
+- legacy ToDoList records imported and indexed;
+- Batches 01 through 05 triaged, documented, audited, checkpointed, or closed as appropriate;
+- production-facing implementation kept narrowly scoped;
+- review-control and architecture boundaries made explicit before future work.
+
+The sprint closed with:
+
+- Batch 01 finalized as a print-review operational batch;
+- Batch 02 finalized as a title/metadata review-control batch;
+- Batch 03 finalized as a Pali protection inventory/review-control batch;
+- Batch 04 finalized as a media/assets audit and review-control batch;
+- Batch 05 documented as architecture/study-order boundary planning only.
+
+---
+
+## Functional Fixes Merged During the Sprint
+
+The sprint produced three narrowly scoped functional fixes:
+
+1. `FLAGFIX_025` -- oversized print images were constrained to prevent print shrink-to-fit instability.
+2. `FLAGFIX_017` -- the reading progress bar was hidden from print/PDF output.
+3. `FLAGFIX_024` -- print `h5` review heading styling was standardized while preserving online collapsible behavior.
+
+No other broad functional implementation should be inferred from the sprint records.
+
+---
+
+## Docs, Audit, and Roadmap Records Created
+
+The sprint also created a large non-implementation documentation layer, including:
+
+- FlagFix docs reorganization and navigational indexing
+- legacy ToDoList imports
+- Batch 01 closure record
+- Batch 02 partial checkpoint and closure record
+- `FLAGFIX_020` title matrix workflow, pilot expansion, and checkpoint
+- `FLAGFIX_021` date metadata audit and checkpoint
+- Batch 03 Pali protection audit and closure
+- Batch 04 media/assets audit and closure
+- `FLAGFIX_022` media evidence audit
+- `FLAGFIX_022A` corrupted URL hardening plan
+- `FLAGFIX_022B` media evidence markup normalization plan
+- `FLAGFIX_022` hardening roadmap
+- global sanity checkpoint after Batch 04
+- Batch 05 architecture checkpoint
+- final FlagFix sprint closure record
+
+These artifacts should be treated as the authoritative planning and review-control baseline for any future sprint.
+
+---
+
+## Open Hardening Items That Must Not Be Implemented Without a New Gate
+
+The following fronts remain open but blocked pending new scope approval:
+
+- `FLAGFIX_022A` source protection / corrupted URL hardening
+- `FLAGFIX_022B` media evidence markup normalization
+- further `FLAGFIX_020` title matrix expansion and any downstream title corrections
+- deeper `FLAGFIX_021` date metadata review and any review-box or metadata behavior changes
+- any Batch 05 study-order, registry, graph, Navigator, or AXIS-Cosmos implementation
+
+None of these items should move into implementation without:
+
+- a dedicated issue;
+- a dedicated branch and PR;
+- explicit changed-file scope;
+- test and rollback posture;
+- explicit publication approval if generated/static output is touched.
+
+---
+
+## Recommended Next Fronts
+
+The most reasonable next fronts after FlagFix are:
+
+### AXIS-Navigator
+
+Treat as a separate architecture/planning track unless and until a narrow implementation scope is approved.
+
+### FLAGFIX_022A / 022B Hardening
+
+These are the clearest technical hardening fronts with existing audit and roadmap material already in place.
+
+### AXIS-Cosmos / Study Order Registry
+
+Treat as docs-first architecture work only, not as immediate graph or UI implementation.
+
+---
+
+## Recommendation for the Next Active Sprint
+
+The next active sprint should begin with docs-only planning, not code.
+
+That means:
+
+- select one narrow target;
+- restate constraints explicitly;
+- confirm source-of-truth boundaries;
+- record the intended issue/branch/PR gate before implementation starts.
+
+This keeps post-FlagFix work aligned with the discipline that made the sprint reviewable and reversible.
+
+---
+
+## Rollback and Safety Note
+
+This document is informational only.
+
+It authorizes no implementation, no rebuild, no renderer changes, no metadata changes, no static-site output changes, and no deployment or Cloudflare changes.
+
+If ever removed, it can be reverted as a docs-only change without affecting production behavior.


### PR DESCRIPTION
## Summary

Adds a docs-only post-FlagFix handoff for AXIS-NIDDHI after the FlagFix sprint closure.

This document records:
- final FlagFix sprint state
- functional fixes merged during the sprint
- docs/audit/roadmap records created
- open hardening fronts that require new gates
- recommended next sprint fronts

## Scope

Docs-only informational handoff.

No implementation is authorized by this PR.

## Files changed

- docs/AXIS_NIDDHI_POST_FLAGFIX_HANDOFF_2026-05-09.md

## Safety

Does not touch:
- pipeline
- renderer
- CSL
- templates
- JS/CSS
- metadata
- static-site output
- deploy/Cloudflare config

## Next recommended fronts

- AXIS-Navigator planning
- FLAGFIX_022A / 022B hardening planning
- AXIS-Cosmos / Study Order Registry architecture work