### PR TITLE
build(showcase): freeze translated static preview

### DIFF
--- a/pipeline/13-static-site/build_meta.json
+++ b/pipeline/13-static-site/build_meta.json
@@ -1,11 +1,11 @@
 {
-  "build_id": "e6ba6242483a9a48",
-  "tree_sha256": "e6ba6242483a9a484d528e42230882b9452be86af443e8aff185cd2e8bf2aecd",
+  "build_id": "68f425b77d687a68",
+  "tree_sha256": "68f425b77d687a685ee2fdc1c3374d2d8b09acabb2dab66017a282b70a22b137",
   "engine": "3.0.2-S14-S15-C1-C3",
-  "generated_at": "2026-04-23T22:19:21Z",
-  "elapsed_s": 29.29,
+  "generated_at": "2026-05-09T14:48:30Z",
+  "elapsed_s": 85.94,
   "posts_total": 748,
-  "posts_rebuilt": 0,
-  "posts_skipped": 748,
+  "posts_rebuilt": 748,
+  "posts_skipped": 0,
   "errors": 0
 }

--- a/pipeline/13-static-site/index.json
+++ b/pipeline/13-static-site/index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-23T22:18:53Z",
+  "generated_at": "2026-05-09T14:48:19Z",
   "total_posts": 748,
   "schema": "axis-niddhi-v3",
   "sections": [


### PR DESCRIPTION
## Summary

Freezes the locally validated translated static preview build.

Validated locally with:



Visual/manual checks passed for:
- archive
- search index
- TL.JJ.008
- BD.AA.007
- TL.EE.003
- BD.AA.002

This PR intentionally includes only the minimal served static-site metadata/index changes from the approved showcase build.

## Scope

Included:
- pipeline/13-static-site/build_meta.json
- pipeline/13-static-site/index.json

Excluded:
- SSG cache
- Translation_Control_Center.csv
- 09-csl
- 03-translations
- pipeline scripts
- full rebuild/pipeline changes

## Guardrails

- No production/published folder touched
- No pipeline rerun after freeze commit
- No translation metadata committed
- No cache committed
