### PR TITLE
feat: add NANA fixture capsule artifacts

### DIFF
--- a/pipeline/capsule/nana/answer_validation/answer-validation-dukkha-bootstrap-v1.json
+++ b/pipeline/capsule/nana/answer_validation/answer-validation-dukkha-bootstrap-v1.json
@@ -1,0 +1,20 @@
+{
+  "answer_validation_id": "val-fixture-001",
+  "concept_id": "dukkha",
+  "llm_called": false,
+  "gate_decision": "MOCK_ONLY",
+  "answer_validation_status": "NOT_APPLICABLE_NO_LLM_CALL",
+  "display_allowed": false,
+  "artifact_status": "fixture_only_not_for_doctrinal_use",
+  "provider_run_type": "offline_fixture",
+  "canonical_refs_found": [],
+  "unknown_refs_found": [],
+  "checks": {
+    "raw_answer_present": true,
+    "sources_section_present": false,
+    "refs_within_allowed_set": true,
+    "no_canonical_authority_claim": true,
+    "marked_derivative": true,
+    "quality_unverified": true
+  }
+}

--- a/pipeline/capsule/nana/council/council-dukkha-bootstrap-v1.json
+++ b/pipeline/capsule/nana/council/council-dukkha-bootstrap-v1.json
@@ -1,0 +1,20 @@
+{
+  "council_id": "council-fixture-001",
+  "concept_id": "dukkha",
+  "consensus_status": "NO_REAL_COUNCIL_YET",
+  "citation_agreement_score": 0.0,
+  "hallucination_risk": "not_evaluated",
+  "llm_called": false,
+  "artifact_status": "fixture_only_not_for_doctrinal_use",
+  "provider_run_type": "offline_fixture",
+  "candidates": [
+    {
+      "candidate_id": "run-fixture-mock-001",
+      "provider": "mock",
+      "answer_status": "simulated",
+      "cited_refs": [],
+      "external_claims_detected": false,
+      "notes": "Static fixture candidate."
+    }
+  ]
+}

--- a/pipeline/capsule/nana/execution/execution-dukkha-mock-bootstrap-v1.json
+++ b/pipeline/capsule/nana/execution/execution-dukkha-mock-bootstrap-v1.json
@@ -1,0 +1,15 @@
+{
+  "execution_id": "execution-fixture-mock-001",
+  "concept_id": "dukkha",
+  "provider": "mock",
+  "run_type": "offline_fixture",
+  "artifact_status": "fixture_only_not_for_doctrinal_use",
+  "prompt_package": {
+    "question": "What is dukkha?",
+    "canonical_refs": [
+      "DS.II.003",
+      "IS.BB.005",
+      "TL.KK.003"
+    ]
+  }
+}

--- a/pipeline/capsule/nana/execution/execution-dukkha-none-bootstrap-v1.json
+++ b/pipeline/capsule/nana/execution/execution-dukkha-none-bootstrap-v1.json
@@ -1,0 +1,15 @@
+{
+  "execution_id": "execution-fixture-none-001",
+  "concept_id": "dukkha",
+  "provider": "none",
+  "run_type": "offline_fixture",
+  "artifact_status": "fixture_only_not_for_doctrinal_use",
+  "prompt_package": {
+    "question": "What is dukkha?",
+    "canonical_refs": [
+      "DS.II.003",
+      "IS.BB.005",
+      "TL.KK.003"
+    ]
+  }
+}

--- a/pipeline/capsule/nana/manifest.json
+++ b/pipeline/capsule/nana/manifest.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "v1",
+  "generated_by": "axis-nana-fixture",
+  "artifact_set_id": "static_bridge_sample_v1",
+  "artifact_status": "fixture_only_not_for_doctrinal_use",
+  "provider_run_type": "offline_fixture",
+  "concepts": [
+    "dukkha"
+  ],
+  "artifacts_by_concept": {
+    "dukkha": {
+      "execution_none": "execution/execution-dukkha-none-bootstrap-v1.json",
+      "execution_mock": "execution/execution-dukkha-mock-bootstrap-v1.json",
+      "provider_none": "provider_runs/provider-dukkha-none-bootstrap-v1.json",
+      "provider_mock": "provider_runs/provider-dukkha-mock-bootstrap-v1.json",
+      "council": "council/council-dukkha-bootstrap-v1.json",
+      "answer_validation": "answer_validation/answer-validation-dukkha-bootstrap-v1.json"
+    }
+  }
+}

--- a/pipeline/capsule/nana/provider_runs/provider-dukkha-mock-bootstrap-v1.json
+++ b/pipeline/capsule/nana/provider_runs/provider-dukkha-mock-bootstrap-v1.json
@@ -1,0 +1,22 @@
+{
+  "provider": "mock",
+  "provider_status": "offline",
+  "provider_decision": "MOCK_ONLY",
+  "llm_called": false,
+  "answer_generated": true,
+  "simulated_answer": "This is a simulated fixture response. It does not represent actual doctrine. It is purely for testing the static bridge.",
+  "provider_backend": "mock_engine",
+  "model_requested": "mock-v1",
+  "provider_error": null,
+  "raw_answer": "This is a simulated fixture response. It does not represent actual doctrine. It is purely for testing the static bridge.",
+  "answer_quality_flag": "simulated",
+  "provider_run_id": "run-fixture-mock-001",
+  "provider_run_type": "offline_fixture",
+  "artifact_status": "fixture_only_not_for_doctrinal_use",
+  "canonical_status": "non_canonical",
+  "canonical_refs": [
+    "DS.II.003",
+    "IS.BB.005",
+    "TL.KK.003"
+  ]
+}

--- a/pipeline/capsule/nana/provider_runs/provider-dukkha-none-bootstrap-v1.json
+++ b/pipeline/capsule/nana/provider_runs/provider-dukkha-none-bootstrap-v1.json
@@ -1,0 +1,22 @@
+{
+  "provider": "none",
+  "provider_status": "offline",
+  "provider_decision": "DRY_RUN_ONLY",
+  "llm_called": false,
+  "answer_generated": false,
+  "simulated_answer": null,
+  "provider_backend": null,
+  "model_requested": null,
+  "provider_error": null,
+  "raw_answer": null,
+  "answer_quality_flag": null,
+  "provider_run_id": "run-fixture-none-001",
+  "provider_run_type": "offline_fixture",
+  "artifact_status": "fixture_only_not_for_doctrinal_use",
+  "canonical_status": "non_canonical",
+  "canonical_refs": [
+    "DS.II.003",
+    "IS.BB.005",
+    "TL.KK.003"
+  ]
+}


### PR DESCRIPTION
Wave 2c.4h redo — official fixture-only capsule promotion via validated toolchain.

This replaces the closed PR #117 (protocol violation via inline heredoc).

Promoted via:
- scripts/nana/promote_to_capsule.py --fixture-only --execute
- axis-nana-lab @ c8fc900 (PR #10, Wave 2c.4g+)

Validation:
- validate_promotion.py — 13/13 gates passed on source before copy
- tmp/manifest.json re-validated after copy, before atomic rename

Artifacts: 7 JSON files
- pipeline/capsule/nana/manifest.json
- pipeline/capsule/nana/execution/ ×2
- pipeline/capsule/nana/provider_runs/ ×2
- pipeline/capsule/nana/council/ ×1
- pipeline/capsule/nana/answer_validation/ ×1

No README promoted.
No build.py run.
No provider execution.
No API calls.
No production touched.
No rescue touched.
Future NIDDHI build hook (_copy_nana_static_artifacts) already exists but was NOT run in this wave.