### PR TITLE
feat(flagfix): add PT title language QA gate

### DIFF
--- a/docs/FlagFix/FLAGFIX_030_TITLE_QA_GATE.md
+++ b/docs/FlagFix/FLAGFIX_030_TITLE_QA_GATE.md
@@ -1,0 +1,122 @@
+# FLAGFIX_030 - Title QA gate before SP10/SP11 apply
+
+Date: 2026-05-18
+Workspace: `/home/sanghop/axis/axis-niddhi-production`
+Scope: read-only QA tool plus documentation
+
+## Purpose
+
+Create a small reusable gate that audits `titles.pt` values in CSL identity metadata before any future `SP10` or `SP11` apply batch accepts DeepL-derived PT titles.
+
+This responds to #FlagFix_028 and #FlagFix_029:
+
+- `LD.AA.000` had `titles.pt = "Vivendo il Dhamma"`.
+- The source marker was `pt_source = "deepl_v5"`, pointing more strongly to the `SP10_translate_deepl.py` initial translation path than to `SP11_translate_titles.py`.
+- #FlagFix_029 found many `titles.pt = null` values, so the gate must be null-safe.
+
+## Tool
+
+Added:
+
+```text
+pipeline/scripts/tools/audit_pt_titles_language_contamination.py
+```
+
+Default audit root:
+
+```text
+pipeline/09-csl
+```
+
+Optional root:
+
+```bash
+python3 pipeline/scripts/tools/audit_pt_titles_language_contamination.py --csl-root pipeline/09-csl
+```
+
+## Markers
+
+The first marker set targets suspicious Italian fragments in PT-BR titles:
+
+```text
+ il
+ lo
+ gli
+ della
+ del
+ delle
+ degli
+ nell
+ sull
+ alla
+ al
+```
+
+The audit pads and lowercases each title before matching, so short markers can be detected without crashing on `null`.
+
+## Output
+
+The tool prints:
+
+```text
+checked=<count>
+null_pt_titles=<count>
+hits=<count>
+```
+
+Each hit prints:
+
+```text
+PD#PN | file path | title | matched markers
+```
+
+Exit codes:
+
+```text
+0 = audit completed with no hits
+1 = audit completed and found suspicious hits
+2 = root/path/JSON read failure prevents audit
+```
+
+## Validation
+
+Commands run:
+
+```bash
+python3 pipeline/scripts/tools/audit_pt_titles_language_contamination.py
+python3 pipeline/scripts/tools/audit_pt_titles_language_contamination.py --csl-root pipeline/09-csl
+```
+
+Observed result for both commands:
+
+```text
+checked=748
+null_pt_titles=439
+hits=0
+```
+
+This matches the expected state after #FlagFix_028: no remaining Italian-marker `titles.pt` hits in current CSL metadata.
+
+## Operational guidance
+
+Run this audit before any future title-writing batch:
+
+```bash
+python3 pipeline/scripts/tools/audit_pt_titles_language_contamination.py
+```
+
+If it exits `1`, do not promote the batch blindly. Inspect each hit and route suspected false positives or true contamination through the title review workflow.
+
+This tool is a guard, not a correction tool. It does not modify metadata, body content, renderer code, static output, or deployment surfaces.
+
+## No-change confirmation
+
+No DeepL call was made.
+No translation was run.
+No CSL content was modified.
+No build was run.
+No pipeline was run.
+No deploy was run.
+No Netlify/Vitrine update was made.
+No Cloudflare configuration was touched.
+`/home/sanghop/axis/axis-niddhi-published` was not touched.

--- a/pipeline/scripts/tools/audit_pt_titles_language_contamination.py
+++ b/pipeline/scripts/tools/audit_pt_titles_language_contamination.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Audit CSL identity metadata for suspicious PT title language contamination.
+
+Read-only by design:
+- reads pipeline/09-csl/*/meta/identity.json
+- never writes to CSL
+- never calls DeepL or translation services
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+MARKERS = [
+    " il ",
+    " lo ",
+    " gli ",
+    " della ",
+    " del ",
+    " delle ",
+    " degli ",
+    " nell",
+    " sull",
+    " alla ",
+    " al ",
+]
+
+
+def default_csl_root() -> Path:
+    return Path(__file__).resolve().parents[3] / "pipeline" / "09-csl"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("top-level JSON is not an object")
+    return data
+
+
+def audit(csl_root: Path) -> tuple[int, int, list[tuple[str, Path, str, list[str]]]]:
+    if not csl_root.exists():
+        raise FileNotFoundError(f"CSL root does not exist: {csl_root}")
+    if not csl_root.is_dir():
+        raise NotADirectoryError(f"CSL root is not a directory: {csl_root}")
+
+    identity_paths = sorted(csl_root.glob("*/meta/identity.json"))
+    if not identity_paths:
+        raise FileNotFoundError(f"No identity.json files found under: {csl_root}")
+
+    checked = 0
+    null_pt_titles = 0
+    hits: list[tuple[str, Path, str, list[str]]] = []
+
+    for identity_path in identity_paths:
+        checked += 1
+        data = load_json(identity_path)
+
+        identity = data.get("identity", {})
+        titles = data.get("titles", {})
+        pdpn = identity.get("pdpn") or identity_path.parent.parent.name
+
+        pt_title = titles.get("pt") if isinstance(titles, dict) else None
+        if pt_title is None:
+            null_pt_titles += 1
+            continue
+
+        title = str(pt_title)
+        low_title = f" {title.lower()} "
+        matched = [marker.strip() for marker in MARKERS if marker in low_title]
+
+        if matched:
+            hits.append((str(pdpn), identity_path, title, matched))
+
+    return checked, null_pt_titles, hits
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only audit for suspicious Italian markers in CSL titles.pt fields."
+    )
+    parser.add_argument(
+        "--csl-root",
+        type=Path,
+        default=default_csl_root(),
+        help="Path to pipeline/09-csl (default: repository pipeline/09-csl)",
+    )
+    args = parser.parse_args()
+
+    try:
+        checked, null_pt_titles, hits = audit(args.csl_root)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"checked={checked}")
+    print(f"null_pt_titles={null_pt_titles}")
+    print(f"hits={len(hits)}")
+
+    for pdpn, path, title, markers in hits:
+        print(f"{pdpn} | {path} | {title} | {', '.join(markers)}")
+
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds #FlagFix_030: a reusable read-only QA gate for PT title language contamination before future SP10/SP11 apply batches.

Files added:

- `pipeline/scripts/tools/audit_pt_titles_language_contamination.py`
- `docs/FlagFix/FLAGFIX_030_TITLE_QA_GATE.md`

## Validation

Current audit result:

```text
checked=748
null_pt_titles=439
hits=0
````

`git diff --check` passed cleanly.

## Safety

No DeepL call was made.
No translation was run.
No CSL content was modified.
No build was run.
No pipeline was run.
No deploy was run.
No Netlify/Vitrine update was made.
No Cloudflare config was touched.
`/home/sanghop/axis/axis-niddhi-published` was not touched.

## Follow-up

Use this QA gate before any future SP10/SP11 apply batch and before batch promotion to the Netlify Vitrine.