### PR TITLE
chore(flagfix): fence retired print batch tools

### DIFF
--- a/docs/FlagFix/FLAGFIX_033_REMOVE_STALE_PRINT_TRANSLATION_CONTROL.md
+++ b/docs/FlagFix/FLAGFIX_033_REMOVE_STALE_PRINT_TRANSLATION_CONTROL.md
@@ -1,0 +1,83 @@
+# FLAGFIX_033 - Remove stale Print Translation Control Center
+
+Date: 2026-05-18
+Workspace: `/home/sanghop/axis/axis-niddhi-production`
+Scope: remove stale print-specific CSV plus documentation
+
+## Decision
+
+Remove:
+
+```text
+pipeline/metadata/Print_Translation_Control_Center.csv
+```
+
+This file was an old print-batch experiment. #FlagFix_032 showed it was stale/print-specific and contradicted current CSL state in multiple rows, including rows marked pending while PT content and PT titles already exist.
+
+## Official translation selector
+
+The official DeepL batch selector remains:
+
+```text
+pipeline/metadata/Translation_Control_Center.csv
+```
+
+That file was coherent with CSL during #FlagFix_032 and is the control file used by the active translation flow.
+
+This sprint does not modify `Translation_Control_Center.csv`.
+
+## Reference search
+
+Command run:
+
+```bash
+grep -RIn "Print_Translation_Control_Center.csv\|Print_Translation_Control_Center" \
+  pipeline/scripts pipeline/13-ssg docs review 2>/dev/null || true
+```
+
+References found:
+
+```text
+pipeline/scripts/tools/print_batch.py
+pipeline/scripts/tools/create_bilingual_review_snapshot.sh
+docs/FlagFix/FLAGFIX_020_TITLE_MATRIX_EXPANSION_PLAN_2026-05-04.md
+docs/FlagFix/FLAGFIX_032_TRANSLATION_BATCH_PREFLIGHT.md
+docs/MANUAL_OPERACOES_BATCH_PRINT.md
+```
+
+Assessment:
+
+- No active `SP10`/`SP11` DeepL selector dependency was found.
+- The script references are print/review-surface references, not active translation batch selection.
+- Historical docs are intentionally left unchanged in this sprint.
+- `print_batch.py` may need separate retirement or update if physical print batching is revived.
+
+## Why deletion is appropriate
+
+Keeping the stale CSV creates a risk that operators may confuse it with the official translation selector and use old `YES`/`PENDING` rows for a future batch.
+
+Deleting the file makes that failure mode visible immediately instead of silently allowing stale print-batch data to steer work.
+
+## Script behavior
+
+No script behavior was modified.
+
+Specifically unchanged:
+
+```text
+pipeline/scripts/core/SP10_translate_deepl.py
+pipeline/scripts/core/SP11_translate_titles.py
+```
+
+## No-change confirmation
+
+No DeepL call was made.
+No translation was run.
+No CSL content was modified.
+No `Translation_Control_Center.csv` change was made.
+No build was run.
+No pipeline was run.
+No deploy was run.
+No Netlify/Vitrine update was made.
+No Cloudflare configuration was touched.
+`/home/sanghop/axis/axis-niddhi-published` was not touched.

--- a/docs/FlagFix/FLAGFIX_034_FENCE_PRINT_BATCH_TOOLS.md
+++ b/docs/FlagFix/FLAGFIX_034_FENCE_PRINT_BATCH_TOOLS.md
@@ -1,0 +1,86 @@
+# FLAGFIX_034 - Fence print-batch tools referencing removed CSV
+
+Date: 2026-05-18
+Workspace: `/home/sanghop/axis/axis-niddhi-production`
+Scope: fence/deprecate print-batch references to removed CSV
+
+## Context
+
+#FlagFix_033 removed:
+
+```text
+pipeline/metadata/Print_Translation_Control_Center.csv
+```
+
+That file was an old print-batch experiment and must not be confused with the official SP10/DeepL selector.
+
+The official translation selector remains:
+
+```text
+pipeline/metadata/Translation_Control_Center.csv
+```
+
+## Tools inspected
+
+```text
+pipeline/scripts/tools/print_batch.py
+pipeline/scripts/tools/create_bilingual_review_snapshot.sh
+```
+
+## Behavior after fencing
+
+### `print_batch.py`
+
+Status: fenced.
+
+This tool's primary workflow depends on the removed print CSV. It now exits immediately with code `2` unless explicitly allowed for archaeology.
+
+Override:
+
+```bash
+AXIS_ALLOW_RETIRED_PRINT_BATCH_TOOL=1
+```
+
+The error explains:
+
+- the print-batch workflow was retired by #FlagFix_033;
+- `Translation_Control_Center.csv` remains official for SP10/DeepL;
+- `Print_Translation_Control_Center.csv` must not be recreated without explicit review.
+
+### `create_bilingual_review_snapshot.sh`
+
+Status: deprecation message updated, not hard-fenced.
+
+This script's primary purpose is review snapshot creation, not print batching. It no longer points operators to `Print_Translation_Control_Center.csv` or `print_batch.py` as the next print path. Its summary now says the print-batch workflow was retired by #FlagFix_033 and that the removed CSV should not be recreated without explicit review.
+
+## Why the CSV was not restored
+
+Restoring `Print_Translation_Control_Center.csv` would reintroduce stale, contradictory print-batch state that #FlagFix_032 identified and #FlagFix_033 intentionally removed.
+
+If physical print batching is revived later, it should receive a fresh control artifact or a redesigned workflow, not resurrect the removed CSV silently.
+
+## Script behavior
+
+No SP10/SP11 behavior was modified.
+
+Unchanged:
+
+```text
+pipeline/scripts/core/SP10_translate_deepl.py
+pipeline/scripts/core/SP11_translate_titles.py
+pipeline/metadata/Translation_Control_Center.csv
+```
+
+## No-change confirmation
+
+No DeepL call was made.
+No translation was run.
+No CSL content was modified.
+No `Translation_Control_Center.csv` change was made.
+No `Print_Translation_Control_Center.csv` restore was made.
+No build was run.
+No pipeline was run.
+No deploy was run.
+No Netlify/Vitrine update was made.
+No Cloudflare configuration was touched.
+`/home/sanghop/axis/axis-niddhi-published` was not touched.

--- a/pipeline/scripts/tools/create_bilingual_review_snapshot.sh
+++ b/pipeline/scripts/tools/create_bilingual_review_snapshot.sh
@@ -498,7 +498,7 @@ fi
     echo ""
     echo "## Next Steps"
     echo "1. Review and print from \`$REVIEW_PIPELINE/13-static-site\`."
-    echo "2. Validate PT-BR quality using \`$REVIEW_PIPELINE/metadata/Print_Translation_Control_Center.csv\`."
+    echo "2. Do not use or recreate \`Print_Translation_Control_Center.csv\`; that print-batch workflow was retired by #FlagFix_033."
     echo "3. If approved, promote this snapshot toward canonical release governance."
     echo ""
     echo "Thank you for this careful run. May this effort support continuity and future translators."
@@ -507,10 +507,10 @@ fi
 ok "Review summary report: $SUMMARY_REPORT"
 
 echo ""
-echo -e "${CYAN}Print readiness${NC}"
-echo -e "  CSV governance: $REVIEW_PIPELINE/metadata/Print_Translation_Control_Center.csv"
-echo -e "  Print tool    : $REVIEW_PIPELINE/scripts/tools/print_batch.py"
-echo -e "  Run           : python3 $REVIEW_PIPELINE/scripts/tools/print_batch.py"
+echo -e "${CYAN}Print batch workflow retired${NC}"
+echo -e "  Retired by   : #FlagFix_033"
+echo -e "  Official CSV : Translation_Control_Center.csv remains official for SP10/DeepL"
+echo -e "  Do not recreate Print_Translation_Control_Center.csv without explicit review."
 echo ""
 
 sleep "$FINAL_PAUSE_SECONDS" 2>/dev/null || true

--- a/pipeline/scripts/tools/print_batch.py
+++ b/pipeline/scripts/tools/print_batch.py
@@ -58,6 +58,17 @@ W = "\033[0;37m"   # Gray
 B = "\033[1m"      # Bold
 N = "\033[0m"      # Reset
 
+if os.environ.get("AXIS_ALLOW_RETIRED_PRINT_BATCH_TOOL") != "1":
+    print(
+        "ERROR: This print-batch workflow was retired by #FlagFix_033 because "
+        "Print_Translation_Control_Center.csv was removed. "
+        "Translation_Control_Center.csv remains official for SP10/DeepL. "
+        "Do not recreate Print_Translation_Control_Center.csv without explicit review. "
+        "Set AXIS_ALLOW_RETIRED_PRINT_BATCH_TOOL=1 only for supervised archaeology.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
 
 def banner():
     print(f"""


### PR DESCRIPTION
## Summary

Adds #FlagFix_034: fences retired print-batch tools after #FlagFix_033 removed the stale Print_Translation_Control_Center.csv.

Also backfills the #FlagFix_033 decision document, which was present locally but did not land in origin/main with PR #126.

## Files changed

- docs/FlagFix/FLAGFIX_033_REMOVE_STALE_PRINT_TRANSLATION_CONTROL.md
- docs/FlagFix/FLAGFIX_034_FENCE_PRINT_BATCH_TOOLS.md
- pipeline/scripts/tools/print_batch.py
- pipeline/scripts/tools/create_bilingual_review_snapshot.sh

## Behavior

- print_batch.py now fails immediately with exit code 2 unless explicitly allowed with AXIS_ALLOW_RETIRED_PRINT_BATCH_TOOL=1.
- create_bilingual_review_snapshot.sh no longer points operators to Print_Translation_Control_Center.csv or print_batch.py; it states that the print-batch workflow was retired by #FlagFix_033.

## Safety

Print_Translation_Control_Center.csv was not restored.
Translation_Control_Center.csv was not modified.
SP10/SP11 behavior was not modified.
No CSL content was modified.
No DeepL call was made.
No translation was run.
No build/pipeline/deploy was run.
No Netlify/Vitrine or Cloudflare changes were made.
/home/sanghop/axis/axis-niddhi-published was not touched.

## Validation

- python3 -m py_compile pipeline/scripts/tools/print_batch.py passed.
- bash -n pipeline/scripts/tools/create_bilingual_review_snapshot.sh passed.
- git diff --check passed.