### PR TITLE
copy(flagfix): improve awaiting translation label

### DIFF
--- a/docs/FlagFix/FLAGFIX_036_AWAITING_TRANSLATION_LABEL.md
+++ b/docs/FlagFix/FLAGFIX_036_AWAITING_TRANSLATION_LABEL.md
@@ -1,0 +1,70 @@
+# FLAGFIX_036 - Improve pending translation label copy
+
+Date: 2026-05-18
+Workspace: `/home/sanghop/axis/axis-niddhi-production`
+Scope: visual copy only for untranslated archive/list entries
+
+## Change
+
+Old archive/list label:
+
+```text
+pending translation / pendente de tradução
+```
+
+New archive/list label:
+
+```text
+Awaiting translation / Aguardando tradução
+```
+
+The new copy is more human and intentional for the Vitrine surface. It communicates that translation is awaited, not abandoned as an administrative pending item.
+
+## Files changed
+
+```text
+pipeline/13-ssg/templates/index.html
+pipeline/13-static-site/archive.html
+```
+
+## Source of truth
+
+The authoritative source is the SSG archive/index template:
+
+```text
+pipeline/13-ssg/templates/index.html
+```
+
+`pipeline/13-static-site/archive.html` is generated static output, but it is tracked in this repository. It was updated by the same exact copy replacement to keep source and generated archive parity without running a build.
+
+## Grep summary
+
+Before:
+
+```text
+pipeline/13-ssg/templates/index.html: old=1 new=0
+pipeline/13-static-site/archive.html: old=439 new=0
+```
+
+After:
+
+```text
+pipeline/13-ssg/templates/index.html: old=0 new=1
+pipeline/13-static-site/archive.html: old=0 new=439
+```
+
+The broader search no longer finds the old `pending translation / pendente de tradução` label in the searched project surfaces.
+
+## No-change confirmation
+
+No CSL content was modified.
+No `Translation_Control_Center.csv` change was made.
+No SP10/SP11 behavior was modified.
+No DeepL call was made.
+No translation was run.
+No build was run.
+No pipeline was run.
+No deploy was run.
+No Netlify/Vitrine update was made.
+No Cloudflare configuration was touched.
+`/home/sanghop/axis/axis-niddhi-published` was not touched.

--- a/pipeline/13-ssg/templates/index.html
+++ b/pipeline/13-ssg/templates/index.html
@@ -301,7 +301,7 @@
           <span class="pt-badge pt-badge-title">T</span>
         {%- endif %}
       {%- else %}
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
       {%- endif %}
     </div>
   </div>

--- a/pipeline/13-static-site/archive.html
+++ b/pipeline/13-static-site/archive.html
@@ -6052,7 +6052,7 @@
       Neuroscience Says There Is No Free Will That Is A Misinterpretation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6064,7 +6064,7 @@
       The Double Slit Experiment
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6076,7 +6076,7 @@
       Vision Cakkhu Vinnana Is Not Just Seeing
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6088,7 +6088,7 @@
       What Is Mind How Do We Experience The Outside World
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6100,7 +6100,7 @@
       Amazingly Fast Time Evolution Of A Thought Citta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6112,7 +6112,7 @@
       Immoral Deeds Ditthi Is Key
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6124,7 +6124,7 @@
       Key To Sotapanna Stage Ditthi And Vicikicca
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6136,7 +6136,7 @@
       Abhidhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6148,7 +6148,7 @@
       Abhidhamma Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6160,7 +6160,7 @@
       Essential Abhidhamma The Basics
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6172,7 +6172,7 @@
       Amazing Mind Namagotta Memories
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6184,7 +6184,7 @@
       Citta And Cetasika How Vinnana Consciousness Arises
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6196,7 +6196,7 @@
       State Of Mind In Absence Of Citta Vithi
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6208,7 +6208,7 @@
       Citta Vithi Processing Sense Inputs
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6220,7 +6220,7 @@
       Javana Of A Citta The Root Of Mental Power
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6232,7 +6232,7 @@
       Cetasika Connection To Gati
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6244,7 +6244,7 @@
       The Mind
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6256,7 +6256,7 @@
       What Is A Thought
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6268,7 +6268,7 @@
       What Is In A Thought Why Gathi Are So Important
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6280,7 +6280,7 @@
       Thoughts Citta Consciousness Vinnana And Mind Hadaya Vatthu Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6292,7 +6292,7 @@
       2 Vinnana Consciousness Can Be Of Many Different Types And Forms
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6304,7 +6304,7 @@
       3 Vinnana Is Not A Thought What Is Subconscious
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6316,7 +6316,7 @@
       Gandhabbaya Manomaya Kaya
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6328,7 +6328,7 @@
       Gandhabbaya Manomaya Kaya Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6340,7 +6340,7 @@
       Gandhabba Netherworld Paraloka
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6352,7 +6352,7 @@
       Ghost In The Machine Manomaya Kaya
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6364,7 +6364,7 @@
       Manomaya Kaya Gandhabba And The Physical Body
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6376,7 +6376,7 @@
       Brain Interface Between Mind And Body
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6388,7 +6388,7 @@
       Manomaya Kaya And Out Of Body Experience Obe
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6400,7 +6400,7 @@
       Cuti Patisandhi An Abhidhamma Description
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6412,7 +6412,7 @@
       Role Of The Brain In Human Consciousness
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6424,7 +6424,7 @@
       Abhidhamma Via Science
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6436,7 +6436,7 @@
       The Origin Of Matter Suddhatthaka
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6448,7 +6448,7 @@
       What Are Dhamma A Deeper Analysis
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6460,7 +6460,7 @@
       Pabhassara Citta Radiant Mind Bhavanga
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6481,7 +6481,7 @@
       Kama Raga Dominates Rupa Raga And Arupa Raga
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6493,7 +6493,7 @@
       Buddha Dhamma Advanced
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6505,7 +6505,7 @@
       Pali Suttas In Tipie1B9Adaka Direct Translations Are Wrong
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6517,7 +6517,7 @@
       Rupa And Rupakkhandha Not External Objects
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6529,7 +6529,7 @@
       Viparie1B987Ama Two Meanings
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6541,7 +6541,7 @@
       Arammae1B987A Sensory Input Initiates Critical Processes
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6562,7 +6562,7 @@
       Buddhist Chanting
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6574,7 +6574,7 @@
       Buddhist Chanting Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6586,7 +6586,7 @@
       Sadhu Symbolizes Purified Heart
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6598,7 +6598,7 @@
       Namaskaraya Homage To Buddha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6610,7 +6610,7 @@
       Supreme Qualities Of Buddha Dhamma Sangha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6622,7 +6622,7 @@
       Five Precepts Panca Sila Recital
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -6634,7 +6634,7 @@
       Sutta Chanting With Pali Text
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7431,7 +7431,7 @@
       12 Key Factors To Be Considered When Meditating For The Sotapanna Stage
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7443,7 +7443,7 @@
       Bhavana Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7455,7 +7455,7 @@
       Introduction To Buddhist Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7467,7 +7467,7 @@
       The Basics
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7479,7 +7479,7 @@
       The Second Level
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7491,7 +7491,7 @@
       Vipassana Vidassana Bhavana Insight Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7503,7 +7503,7 @@
       Ariya Metta Bhavana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7515,7 +7515,7 @@
       Anapanasati Bhavana Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7527,7 +7527,7 @@
       What Is Anapana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7539,7 +7539,7 @@
       Anapanasati Not Breath Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7551,7 +7551,7 @@
       The Basic Formal Anapanasati Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7563,7 +7563,7 @@
       Possible Effects In Meditation Kundalini Awakening
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7575,7 +7575,7 @@
       Key To Anapanasati How To Change Habits And Character Gati
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7587,7 +7587,7 @@
       Introduction To Character Or Personality Gathi
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7599,7 +7599,7 @@
       A Broad View Of The Person Trying To Be A Better Person
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7611,7 +7611,7 @@
       How Character Gathi Leads To Bhava And Jati
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7623,7 +7623,7 @@
       Karaniya Metta Sutta Metta Bhavana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7635,7 +7635,7 @@
       10 Attaining The Sotapanna Stage Via Removing Ditthasava
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7647,7 +7647,7 @@
       Cultivation Of Satta Bojjhanga
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7659,7 +7659,7 @@
       13 Kammatthana Recitations For The Sotapanna Stage
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7671,7 +7671,7 @@
       Meditation Deeper Aspects
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7683,7 +7683,7 @@
       Vipassana Buddhist Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7695,7 +7695,7 @@
       Mind Operates Like A Machine According To Natures Laws
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7707,7 +7707,7 @@
       Sanna Gives Rise To Most Of The Vedana We Experience
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7719,7 +7719,7 @@
       Attaining Nibbana Requires Understanding Buddhas Worldview
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7731,7 +7731,7 @@
       Tae1B987Ha Result Of Sanna Giving Rise To Mind Made Vedana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7743,7 +7743,7 @@
       Buddhist Theory Of Matter Fundamentals
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7755,7 +7755,7 @@
       Anussati Anupassana Mindset Technique
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7767,7 +7767,7 @@
       Myths About Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7779,7 +7779,7 @@
       Simple Way Enhance Merits Kusala
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7791,7 +7791,7 @@
       Samadhi Jhana Magga Phala
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7803,7 +7803,7 @@
       Samadhi Three Kinds Of Mindfulness
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7815,7 +7815,7 @@
       Sotapanna Anugami Getting To Samadhi Via Formal Mediation Sessions
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7827,7 +7827,7 @@
       Are You Not Getting Expected Results From Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7874,7 +7874,7 @@
       Recovering Suffering Free Pure Mind
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7886,7 +7886,7 @@
       True Happiness Is The Absence Of Suffering
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7898,7 +7898,7 @@
       Uncovering The Suffering Free Pabhassara Mind
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7910,7 +7910,7 @@
       Each Citta Starts With Distorted Sanna
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7922,7 +7922,7 @@
       Contamination Of The Human Mind Based On A Sensory Input
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7934,7 +7934,7 @@
       Contamination Of A Human Mind Detailed Analysis
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7946,7 +7946,7 @@
       Pali Words Writing Pronunciation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7958,7 +7958,7 @@
       Salayatana Are Not Sense Faculties
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7970,7 +7970,7 @@
       Rupa Dhamma Appae1B9Adigha Rupa And Namagotta Memories
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -7991,7 +7991,7 @@
       Dhammapada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8003,7 +8003,7 @@
       Manopubbangama Dhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8015,7 +8015,7 @@
       Sabba Papassa Akaranam
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8027,7 +8027,7 @@
       Appamado Amata Padam
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8039,7 +8039,7 @@
       Na Jacca Vasalo Hoti
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8051,7 +8051,7 @@
       Arogya Parama Labha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8063,7 +8063,7 @@
       Anicca Vata Sankhara
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8075,7 +8075,7 @@
       Atta Hi Attano Natho
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8096,7 +8096,7 @@
       Dhamma And Philosophy
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8108,7 +8108,7 @@
       Dhamma And Philosophy Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8120,7 +8120,7 @@
       Philosophy Of The Mind
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8132,7 +8132,7 @@
       Buddha Dhamma Buddhism Religion
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8144,7 +8144,7 @@
       The Infinity Problem In Buddhism
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8156,7 +8156,7 @@
       Free Will In Buddhism Connection To Sankhara
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8168,7 +8168,7 @@
       Book Reviews
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8180,7 +8180,7 @@
       Why Does The World Exist
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8192,7 +8192,7 @@
       Waking Up By Sam Harris
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8204,7 +8204,7 @@
       The Language Of God By Francis Collins
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8216,7 +8216,7 @@
       Spark Exercise And Brain By John Ratey
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8228,7 +8228,7 @@
       The Life Of The Buddha By Bhikkhu Nanamoli
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8249,7 +8249,7 @@
       Dhamma And Science
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8261,7 +8261,7 @@
       Dhamma And Science Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8273,7 +8273,7 @@
       Dhamma And Science
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8285,7 +8285,7 @@
       Origin Of Life
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8297,7 +8297,7 @@
       Origin Of Life No Traceable Origin
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8309,7 +8309,7 @@
       Human Life Gandhabba And Cell
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8321,7 +8321,7 @@
       Clarification Of Mental Body And Physical Body
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8333,7 +8333,7 @@
       Four Types Of Births In Buddhism
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8345,7 +8345,7 @@
       Conception Abortion Contraception Buddha Dhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8357,7 +8357,7 @@
       Cloning And Gandhabba
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8369,7 +8369,7 @@
       Origin Of Living Cell
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8381,7 +8381,7 @@
       Mystical Phenomena In Buddhism
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8393,7 +8393,7 @@
       Views On Life
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8405,7 +8405,7 @@
       Wrong View Of Life Materialism
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8417,7 +8417,7 @@
       Wrong View Of Creationism Part 1
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8429,7 +8429,7 @@
       Wrong View Of Creationism Part 2
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8441,7 +8441,7 @@
       Worldview Of The Buddha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8453,7 +8453,7 @@
       Buddhist Worldview
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8465,7 +8465,7 @@
       Mind Pleasing Things In The World Arise Via Pae1B9Adicca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8477,7 +8477,7 @@
       Sensory Inputs Initiate Creation Of The World Loka Samudaya
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8489,7 +8489,7 @@
       Sandie1B9Ade1B9Adhiko What Does It Mean
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8501,7 +8501,7 @@
       A Sensory Input Triggers Distorted Sanna And Pancupadanakkhandha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8513,7 +8513,7 @@
       Kama Sanna How To Bypass To Cultivate Satipae1B9Ade1B9Adhana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8525,7 +8525,7 @@
       Loka And Nibbana Aloka Complete Overview
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8537,7 +8537,7 @@
       Contact Between Ayatana Leads To Vipaka Vinnana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8549,7 +8549,7 @@
       How Do Sense Faculties Become Internal Ayatana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8561,7 +8561,7 @@
       Indriya Make Phassa And Ayatana Make Samphassa
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8573,7 +8573,7 @@
       Paticca Samuppada Not Self Or No Self
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8585,7 +8585,7 @@
       Tanha Origin Of Suffering
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8597,7 +8597,7 @@
       Paticca Samuppada Self Exists Due To Avijja
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8609,7 +8609,7 @@
       Kamma Sankhara Abhisankhara Intention
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8621,7 +8621,7 @@
       Vaci Sankhara Sankappa Conscious Thoughts And Vaca Speech
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8633,7 +8633,7 @@
       Tanha Paccaya Upadana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8645,7 +8645,7 @@
       Moha Avijja And Vipaka Vinnana Kamma Vinnana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8657,7 +8657,7 @@
       Iccha Cravings Lead To Upadana To Suffering
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8669,7 +8669,7 @@
       Dhamma Kamma Sankhara Mind Critical Connections
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8681,7 +8681,7 @@
       Paticca Samuppada Mind To Matter
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8693,7 +8693,7 @@
       Ghost 1990 Movie Good Depiction Of Gandhabba Concept
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8705,7 +8705,7 @@
       Mental Body Versus Physical Body
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8717,7 +8717,7 @@
       Framework Of Buddha Dhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8729,7 +8729,7 @@
       First Noble Truth Suffering Dukkha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8741,7 +8741,7 @@
       Dangers Of Wrong Views
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8753,7 +8753,7 @@
       Samma Ditthi Two Types
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8765,7 +8765,7 @@
       Fear Of Nibbana Enlightenment
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8777,7 +8777,7 @@
       Origin Of Life Connection To Dhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8789,7 +8789,7 @@
       Consciousness A Dhamma Perspective
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8801,7 +8801,7 @@
       What Is Consciousness
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8813,7 +8813,7 @@
       What Happens In Other Dimensions
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8825,7 +8825,7 @@
       Six Kinds Of Consciousness In Our 3 D World
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8837,7 +8837,7 @@
       Expanding Consciousness By Using Technology
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8849,7 +8849,7 @@
       Expanding Consciousness By Purifying The Mind
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8861,7 +8861,7 @@
       Buddhism Consistencies With Science
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8873,7 +8873,7 @@
       Second Law Of Thermodynamics Is Part Of Anicca
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8885,7 +8885,7 @@
       Quantum Entanglement We Are All Connected
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8897,7 +8897,7 @@
       Infinity How Big Is It
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8909,7 +8909,7 @@
       Godels Incompleteness Theorem
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8921,7 +8921,7 @@
       Triune Brain How The Mind Rewires The Brain Via Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8933,7 +8933,7 @@
       How Habits Are Formed Scientific View
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -8945,7 +8945,7 @@
       Buddhism Inconsistencies With Science
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9018,7 +9018,7 @@
       Elephants In The Room
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9030,7 +9030,7 @@
       Elephant In The Room 1 Direct Translation Of The Tipitaka
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9042,7 +9042,7 @@
       Idappaccayata Paticca Samuppada Bhava And Jati Within A Lifetime
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9054,7 +9054,7 @@
       Change Of Mindset Due To An Arammana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9066,7 +9066,7 @@
       Khandha In Idappaccayata Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9078,7 +9078,7 @@
       Seeing Is A Series Of Snapshots
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9090,7 +9090,7 @@
       Aggregate Of Forms Collection Of Mental Impressions Of Forms
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9102,7 +9102,7 @@
       Rupakkhandha In Idappaccayata Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9114,7 +9114,7 @@
       Five Aggregates Experiences Of Each Sentient Being
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9126,7 +9126,7 @@
       Pancupadanakkhandha Attachment To Ones Experiences
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9138,7 +9138,7 @@
       Noble Truth Of Suffering Pancupadanakkhandha Dukkha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9150,7 +9150,7 @@
       Sakkaya Ditthi And Pancupadanakkhandha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9162,7 +9162,7 @@
       Bhava And Jati Within A Lifetime Example
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9187,7 +9187,7 @@
       Raga And Jhana Two Commonly Misunderstood Words
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9199,7 +9199,7 @@
       Elephant In The Room 2 Jhana And Kasina
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9211,7 +9211,7 @@
       Janato Passato And Ajaniya Critical Words To Remember
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9223,7 +9223,7 @@
       Samadhi Jhana And Samma Samadhi
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9235,7 +9235,7 @@
       Jhana Jhaya And Jhayi Different Meanings
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9247,7 +9247,7 @@
       Jhana Finer Details
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9259,7 +9259,7 @@
       Samma Samadhi How To Define It
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9271,7 +9271,7 @@
       Ariya Jhana And Anariya Jhana Main Differences
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9283,7 +9283,7 @@
       Elephant In The Room 3 Anapanasati
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9295,7 +9295,7 @@
       Anapanasati Overview
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9307,7 +9307,7 @@
       Assasa Passasa What Do They Mean
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9319,7 +9319,7 @@
       Anapanasati Not About Breath Icchanae1B985Gala Sutta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9331,7 +9331,7 @@
       Maharahulovada Sutta And Anapanasati
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9356,7 +9356,7 @@
       Does Gandhabba Mean Semen
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9377,7 +9377,7 @@
       Parinibbana Of Waharaka Thero
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9389,7 +9389,7 @@
       Puredhamma Essays In A Book Format
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9401,7 +9401,7 @@
       Pure Dhamma Sinhala Translation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9413,7 +9413,7 @@
       Pure Dhamma German Website
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9425,7 +9425,7 @@
       Pure Dhamma Korean Website
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9437,7 +9437,7 @@
       Niramisa Sukha In A Chart
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9449,7 +9449,7 @@
       Pali Glossary With Pronunciation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9461,7 +9461,7 @@
       New Revised Posts
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9473,7 +9473,7 @@
       Pure Dhamma Sitemap
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9485,7 +9485,7 @@
       Pure Dhamma Discussion Forum Guidelines
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9497,7 +9497,7 @@
       Pure Dhamma Reflections On 2019
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9509,7 +9509,7 @@
       Pure Dhamma Reflections On 2018
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9521,7 +9521,7 @@
       Pure Dhamma Reflections On 2017
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9533,7 +9533,7 @@
       Pure Dhamma Reflections On 2016
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9545,7 +9545,7 @@
       Reflections On 2015
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9557,7 +9557,7 @@
       Reflections On 2014
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9591,7 +9591,7 @@
       Misinterpretation Of Anicca And Anatta By Early European Scholars
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9603,7 +9603,7 @@
       Tipitaka English Convention Part 1
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9615,7 +9615,7 @@
       Tipitaka English Convention Part 2
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9627,7 +9627,7 @@
       Historical Background
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9639,7 +9639,7 @@
       Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9651,7 +9651,7 @@
       Counterfeit Buddhism Current Mainstream Buddhism
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9663,7 +9663,7 @@
       Methods Of Delivery Of Dhamma By The Buddha 2
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9675,7 +9675,7 @@
       Questions Buddha Refused To Answer
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9687,7 +9687,7 @@
       Misinterpretations Of Buddha Dhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9699,7 +9699,7 @@
       Preservation Buddha Dhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9711,7 +9711,7 @@
       Historical Timeline Of Edward Conze
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9723,7 +9723,7 @@
       Why Is It Critical To Find The Pure Buddha Dhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9735,7 +9735,7 @@
       Key Problems With Mahayana Teachings
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9747,7 +9747,7 @@
       Saddharma Pundarika Sutra Lotus Sutra A Focused Analysis
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9759,7 +9759,7 @@
       What Is Sunyata Emptiness
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9771,7 +9771,7 @@
       Buddhaghosa And Visuddhimagga Historical Background
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9783,7 +9783,7 @@
       Buddhaghosas Visuddhimagga A Focused Analysis
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9795,7 +9795,7 @@
       Background On The Current Revival Of Buddha Dhamma 2
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9807,7 +9807,7 @@
       Tipitaka Commentaries Helpful Or Misleading
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9828,7 +9828,7 @@
       Do I Have A Mind That Is Fixed And Mine
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9840,7 +9840,7 @@
       Citta Basis Of Experience Actions
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9852,7 +9852,7 @@
       Vipaka Vedana Samphassa Ja Vedana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9864,7 +9864,7 @@
       Kama Guna Origin Of Attachment Tanha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9876,7 +9876,7 @@
       Vision Is A Series Of Snapshots Movie Analogy
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9888,7 +9888,7 @@
       Chachakka Sutta Six Types Of Vipaka Vinnana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9900,7 +9900,7 @@
       Sakkaya Ditthi In Terms Of Atta Self Atma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9912,7 +9912,7 @@
       An Apparent Self Involved In Kamma Generation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9924,7 +9924,7 @@
       Is There A Self
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9936,7 +9936,7 @@
       Does Anatta Refer To A Self
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9948,7 +9948,7 @@
       Cognition Modes Sanjanati Vijanati Pajanati Abhijanati
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9960,7 +9960,7 @@
       Anicca Nature Chasing Worldly Pleasures Is Pointless
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9972,7 +9972,7 @@
       Aniccae1B981 Viparie1B987Ami Annathabhavi A Critical Verse
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9984,7 +9984,7 @@
       Dukkha Previously Unknown Truth About Suffering
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -9996,7 +9996,7 @@
       Atta As Self Wrong Translation In Natumhaka Sutta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -10008,7 +10008,7 @@
       Attato Samanupassati To View Something To Be Of Value
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -10020,7 +10020,7 @@
       Sanna Vipallasa Distorted Perception
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -10032,7 +10032,7 @@
       Sanna All Our Thoughts Arise With Distorted Sanna
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -10044,7 +10044,7 @@
       Upaya And Upadana Two Stages Of Attachment
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -10056,7 +10056,7 @@
       Sensory Experience Basis Of Buddhas Worldview
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -11516,7 +11516,7 @@
       What Are Kilesa Mental Impurities Connection To Cetasika
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -11944,7 +11944,7 @@
       Ye Dhamma Hetuppabhava And Yam Kinci Samudaya Dhammam
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -11956,7 +11956,7 @@
       Samadhi Jhana Magga Phala
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -11968,7 +11968,7 @@
       Samadhi Jhana Magga Phala Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -11980,7 +11980,7 @@
       Vitakka Vicara Savitakka Savicara Avitakka Avicara
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -11992,7 +11992,7 @@
       Jhanic Experience Details
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12004,7 +12004,7 @@
       Ascendance To Nibbana Via Jhana Dhyana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12016,7 +12016,7 @@
       Pannavimutti Arahanthood Without Jhana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12028,7 +12028,7 @@
       Mundane Supramundane Jhana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12040,7 +12040,7 @@
       Nirodha Samapatti Phala Samapatti Jhana And Jhana Samapatti
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12052,7 +12052,7 @@
       Mental Body Gandhabba
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12064,7 +12064,7 @@
       Our Mental Body Gandhabba
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12076,7 +12076,7 @@
       Gandhabba State Tipitaka Evidence
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12088,7 +12088,7 @@
       Antarabhava And Gandhabba
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12100,7 +12100,7 @@
       Anantarika Kamma Gandhabba
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12112,7 +12112,7 @@
       Mental Body Gandhabba Personal Accounts
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12124,7 +12124,7 @@
       Abnormal Births Due To Gandhabba Transformations
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12136,7 +12136,7 @@
       Ahara Food For The Mental Body
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12148,7 +12148,7 @@
       Miccha Ditthi Gandhabba Sotapanna Stage
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12160,7 +12160,7 @@
       Working Of Kamma Critical Role Of Conditions
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12181,7 +12181,7 @@
       Myths Or Realities
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12193,7 +12193,7 @@
       Vedas Originated With Buddha Kassapas Teachings
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12205,7 +12205,7 @@
       Dasa Mara Sena Marasena Ten Defilements
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12217,7 +12217,7 @@
       Animisa Locana Bodhi Pooja
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12229,7 +12229,7 @@
       Paramita How A Puthujjana Becomes A Buddha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12241,7 +12241,7 @@
       Tisarana Vandana And Its Effects On Ones Gathi
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12253,7 +12253,7 @@
       Does The Hell Niraya Exist
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12265,7 +12265,7 @@
       Can Buddhist Meditation Be Dangerous
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12277,7 +12277,7 @@
       Boy Who Remembered Pali Suttas For 1500 Years
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12289,7 +12289,7 @@
       Do Buddhists Pray And Engage In Idol Worshipping
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12310,7 +12310,7 @@
       Buddha Dhamma In A Chart
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12322,7 +12322,7 @@
       Ancient Teeth Found In China Challenge Modern Human Migration Theory
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12334,7 +12334,7 @@
       Mars Curiosity Photos Suggest Life May Have Existed On Red Planet
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12346,7 +12346,7 @@
       Recent Publications On Benefits Of Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12358,7 +12358,7 @@
       Laniakea Our Home Supercluster
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12370,7 +12370,7 @@
       Think Outside The Box
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12382,7 +12382,7 @@
       There Are As Many Creatures On Your Body As There Are People On Earth
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12394,7 +12394,7 @@
       News Article On Robin Williams And Buddhist Meditation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12406,7 +12406,7 @@
       World Historical Timeline
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12418,7 +12418,7 @@
       Second Largest Religion By State In The Us
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12439,7 +12439,7 @@
       Path To Nibbana The Necessary Background
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12451,7 +12451,7 @@
       Path To Nibbana Learning Dhamma To Become A Sotapanna
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12463,7 +12463,7 @@
       Sotapanna Stage From Kama Loka
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12497,7 +12497,7 @@
       Forums
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12509,7 +12509,7 @@
       About Me
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12530,7 +12530,7 @@
       Difference Between Dhamma And Sae1B985Khara
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12542,7 +12542,7 @@
       Difference Between Tanha And Upadana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12554,7 +12554,7 @@
       Anantara Samanantara Paccaya
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12566,7 +12566,7 @@
       Six Root Causes Loka Samudaya Loka Nirodhaya
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12578,7 +12578,7 @@
       Kamma And Paticca Samuppada Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12590,7 +12590,7 @@
       Kama Assada A Root Cause Of Suffering
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12602,7 +12602,7 @@
       Gati Determine Births
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12614,7 +12614,7 @@
       Distortion Of Pali Keywords In Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12639,7 +12639,7 @@
       Patiloma Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12651,7 +12651,7 @@
       Feelings Sukha Dukha Somanassa And Domanassa
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12663,7 +12663,7 @@
       What Is Kama It Is Not Sex
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12675,7 +12675,7 @@
       Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12687,7 +12687,7 @@
       Paticca Samuppada Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12699,7 +12699,7 @@
       Paticca Samuppada Causes And Effects Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12711,7 +12711,7 @@
       Nibbana Ragakkhaya Dosakkhaya Mohakkhaya Part 1
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12723,7 +12723,7 @@
       Panca Nivarana And Sensual Pleasures Kama Raga
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12735,7 +12735,7 @@
       Iccha Tanha Kama Root Causes Of Suffering
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12747,7 +12747,7 @@
       Jati Different Types Of Births
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12759,7 +12759,7 @@
       Bhava Kammic Energy That Can Power An Existence
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12771,7 +12771,7 @@
       Bhava And Punabbhava Kammic Energy Giving Rise To Renewed Existence
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12783,7 +12783,7 @@
       Concepts Of Upadana And Upadanakkhandha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12795,7 +12795,7 @@
       Loka Sutta Origin And Cessation Of The World
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12807,7 +12807,7 @@
       Dukkha Samudaya Starts With Samphassa Ja Vedana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12819,7 +12819,7 @@
       Key Steps Of Kammic Energy Accumulation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12831,7 +12831,7 @@
       Generating Kammic Energy In The Upadana Paccaya Bhava Step
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12843,7 +12843,7 @@
       Vinnana Paccaya Namarupa
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12855,7 +12855,7 @@
       Namarupa Paccaya Salayatana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12867,7 +12867,7 @@
       Kamma And Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12879,7 +12879,7 @@
       Dhamma And Dhamma Different But Related
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12891,7 +12891,7 @@
       Where Are Memories Stored Vinnana Dhatu
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12903,7 +12903,7 @@
       Paticca Samuppada Tilakkhana Four Noble Truths
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12915,7 +12915,7 @@
       Paticca Samuppada Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12927,7 +12927,7 @@
       What Did The Buddha Mean By A Loka
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12939,7 +12939,7 @@
       Future Suffering Loka Dukkha Samudaya Starts With Sensory Input Arammana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12951,7 +12951,7 @@
       Sotapanna One With The Wider Worldview Of The Buddha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12963,7 +12963,7 @@
       Sotapanna Just Starting On The Noble Path
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12975,7 +12975,7 @@
       Yoniso Manasikara And Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12987,7 +12987,7 @@
       Dhamma Different Meanings Depending On The Context
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -12999,7 +12999,7 @@
       Dhammanudhamma Patipatti Connection To Paticca Samuppada Tilakkhana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13011,7 +13011,7 @@
       Where Are Memories Stored Connection To Pancakkhandha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13023,7 +13023,7 @@
       Sakkaya Ditthi And Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13035,7 +13035,7 @@
       Sakkaya Ditthi Wrong View Of Me And Mine
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13047,7 +13047,7 @@
       Anatta And Sakkaya Ditthi Two Different Concepts
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13059,7 +13059,7 @@
       Understanding The Terms In Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13071,7 +13071,7 @@
       Sankhara Many Meanings
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13083,7 +13083,7 @@
       Sae1B985Khara An Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13095,7 +13095,7 @@
       Sankhara Should Not Be Translated As A Single Word
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13107,7 +13107,7 @@
       Kamma And Sankhara Cetana And Sancetana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13119,7 +13119,7 @@
       Kusala Mula Sankhara Needed To Attain Nibbana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13131,7 +13131,7 @@
       Rebirths Take Place According To Abhisankhara
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13143,7 +13143,7 @@
       Vinnana Two Critical Meanings
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13155,7 +13155,7 @@
       Abhisankhara Lead To Kamma Vinnana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13167,7 +13167,7 @@
       Two Types Of Kamma Vinnana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13179,7 +13179,7 @@
       Summary Of Key Concepts About Vinnana And Sankhara
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13191,7 +13191,7 @@
       Anidassana Appatigha Rupa Due To Anidassana Vinnana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13203,7 +13203,7 @@
       Memory Dhamma And Vinnana Dhatu
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13215,7 +13215,7 @@
       Critical Influence Of Wrong Views On Akusala Citta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13227,7 +13227,7 @@
       Near Death Experiences Nde Brain Is Not The Mind
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13239,7 +13239,7 @@
       Gandhabba Mental Body Separating From Physical Body In Jhana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13251,7 +13251,7 @@
       Citta Vithi Fundamental Sensory Unit
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13263,7 +13263,7 @@
       Does Any Object Rupa Last Only 17 Thought Moments
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13275,7 +13275,7 @@
       Pancupadanakkhandha Arises With An Arammana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13287,7 +13287,7 @@
       Paticca Samuppada Cycles
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13299,7 +13299,7 @@
       Idappaccayata Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13311,7 +13311,7 @@
       Avyakata Paticca Samuppada For Vipaka Vinnana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13323,7 +13323,7 @@
       Akusala Mula Upapatti Paticca Samuppada
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13335,7 +13335,7 @@
       How We Create Our Own Rebirths
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13347,7 +13347,7 @@
       Paticca Samuppada In Plain English
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13359,7 +13359,7 @@
       Introduction What Is Suffering
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13371,7 +13371,7 @@
       Introduction 2 The Three Categories Of Suffering
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13383,7 +13383,7 @@
       Avijja Paccaya Sankhara
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13395,7 +13395,7 @@
       Sankhara Paccaya Vinnana 1
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13407,7 +13407,7 @@
       Sankhara Paccaya Vinnana 2
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13419,7 +13419,7 @@
       Difference Between Phassa And Samphassa
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13431,7 +13431,7 @@
       Phassa Paccaya Vedana To Tanha
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13443,7 +13443,7 @@
       Upadana Paccaya Bhava Two Types Of Bhava
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13455,7 +13455,7 @@
       Namarupa Vinnae1B987A Dhamma Closely Related
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13467,7 +13467,7 @@
       Bhava Paccaya Jati Jara Marana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13479,7 +13479,7 @@
       How Are Paticca Samuppada Cycles Initiated
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13491,7 +13491,7 @@
       What Does Paccaya Mean In Paticca Samuppada Effect Is Not Guaranteed
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13503,7 +13503,7 @@
       Imasmim Sati Idam Hoti
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13515,7 +13515,7 @@
       Patthana Dhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13527,7 +13527,7 @@
       Pattana Dhamma Cause Effect Hetu Phala
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13539,7 +13539,7 @@
       Asevana Annamanna Paccaya
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13560,7 +13560,7 @@
       Quantum Mechanics Buddhism Buddha Dhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13572,7 +13572,7 @@
       Quantum Mechanics And Dhamma Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13584,7 +13584,7 @@
       Quantum Mechanics And Consciousness
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13596,7 +13596,7 @@
       Will Quantum Mechanics Be Able To Explain Consciousness
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13608,7 +13608,7 @@
       Observer Effect Quantum Mechanics
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13620,7 +13620,7 @@
       Quantum Mechanics A New Interpretation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13632,7 +13632,7 @@
       What Is A Wave And What Is A Particle
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13644,7 +13644,7 @@
       Photons Are Particles Not Waves
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13656,7 +13656,7 @@
       Basis Of Proposed Interpretation Feynmans Technique Qed
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13668,7 +13668,7 @@
       Feynmans Glass Plate Experiment
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13680,7 +13680,7 @@
       Feynmans Method Of A Particle Exploring All Possible Paths
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13692,7 +13692,7 @@
       Exploring Possible Paths Fermats Principle Least Time
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13713,7 +13713,7 @@
       Buddhist Cosmology Agganna Sutta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13725,7 +13725,7 @@
       Essence Of Buddhism In The First Sutta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13737,7 +13737,7 @@
       Sutta Interpretations
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13749,7 +13749,7 @@
       Sutta Interpretation Uddesa Niddesa Patiniddesa
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13761,7 +13761,7 @@
       Pali Dictionaries Reliability
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13773,7 +13773,7 @@
       Nikaya Sutta Pitaka
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13785,7 +13785,7 @@
       Sutta Learning Sequence For The Present Day
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13797,7 +13797,7 @@
       Maha Satipatthana Sutta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13809,7 +13809,7 @@
       Satipatthana Sutta Structure
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13821,7 +13821,7 @@
       Satipatthana Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13833,7 +13833,7 @@
       Kayanupassana Foundation Iriyapathapabba
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13845,7 +13845,7 @@
       Kayanupassana The Section On Habits Sampajanapabba
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13857,7 +13857,7 @@
       Prerequisites For The Satipatthana Bhavana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13869,7 +13869,7 @@
       Kaya Kaya Kayanupassana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13881,7 +13881,7 @@
       Maha Cattarisaka Sutta Discourse On The Great Forty
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13893,7 +13893,7 @@
       Dhammacakkappavattana Sutta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13905,7 +13905,7 @@
       Dhammacakkappavattana Sutta Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13917,7 +13917,7 @@
       Majjhima Patipada Relinquish Attachments To World
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13929,7 +13929,7 @@
       Tiparivattaya And Twelve Types Of Nana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13941,7 +13941,7 @@
       Relinquishing Defilements Via Three Rounds And Four Stages
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13953,7 +13953,7 @@
       Anguttara Nikaya
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13965,7 +13965,7 @@
       Dasa Akusala Dasa Kusala Basis Buddha Dhamma
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13977,7 +13977,7 @@
       Dasa Akusala Dasa Kusala Basis Of Buddha Dhamma 2
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -13989,7 +13989,7 @@
       Na Cetanakaraniya Sutta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -14001,7 +14001,7 @@
       Pathama Metta Sutta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -14013,7 +14013,7 @@
       Kukkuravatika Sutta Majjhima Nikaya 57 Kammakkhaya
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -14025,7 +14025,7 @@
       Agganna Sutta Discussion Introduction
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -14037,7 +14037,7 @@
       Tapussa Sutta Akuppa Cetovimutti
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -14049,7 +14049,7 @@
       Yamaka Sutta Sn 22 85 Arahanthood Not Annihilation
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -14061,7 +14061,7 @@
       Three Types Of Bodies Potthapada Sutta Dn 9
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15239,7 +15239,7 @@
       Kama Asvada Phassa Paccaya Vedana Samphassa Ja Vedana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15277,7 +15277,7 @@
       Udayavaya Nana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15350,7 +15350,7 @@
       Tables And Summaries
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15362,7 +15362,7 @@
       Pali Glossary A K
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15374,7 +15374,7 @@
       Pali Glossary L Z
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15386,7 +15386,7 @@
       List Of San Words And Other Pali Roots
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15398,7 +15398,7 @@
       89 Or 121 Citta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15410,7 +15410,7 @@
       Cetasika Mental Factors
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15422,7 +15422,7 @@
       Rupa Material Form
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15434,7 +15434,7 @@
       Rupa Generation Mechanisms
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15446,7 +15446,7 @@
       Rupa Kalapas Grouping Of Matter
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15458,7 +15458,7 @@
       Akusala Citta And Akusala Vipaka Citta
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15470,7 +15470,7 @@
       37 Factors Of Enlightenment
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15482,7 +15482,7 @@
       Four Stages Of Nibbana
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15494,7 +15494,7 @@
       Ultimate Realities Table
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   
@@ -15506,7 +15506,7 @@
       31 Realms Of Existence
     </div>
     <div class="index-cell pt pt-missing">
-        <em>pending translation / pendente de tradução</em>
+        <em>Awaiting translation / Aguardando tradução</em>
     </div>
   </div>
   


### PR DESCRIPTION
## Summary

Adds #FlagFix_036: improves the archive/list label for untranslated posts.

## Change

Old:

pending translation / pendente de tradução

New:

Awaiting translation / Aguardando tradução

## Files changed

- pipeline/13-ssg/templates/index.html
- pipeline/13-static-site/archive.html
- docs/FlagFix/FLAGFIX_036_AWAITING_TRANSLATION_LABEL.md

## Notes

The authoritative source is the SSG archive/index template:

- pipeline/13-ssg/templates/index.html

The tracked generated archive was updated for local source/generated parity without running a build:

- pipeline/13-static-site/archive.html

## Validation

- git diff --check passed
- grep summary:
  - pipeline/13-ssg/templates/index.html: old=0 new=1
  - pipeline/13-static-site/archive.html: old=0 new=439

## Safety

No CSL content was modified.
No Translation_Control_Center.csv change was made.
No SP10/SP11 behavior was modified.
No DeepL call was made.
No translation was run.
No build/pipeline/deploy was run.
No Netlify/Vitrine or Cloudflare changes were made.
/home/sanghop/axis/axis-niddhi-published was not touched.