### PR TITLE
docs(flagfix): close title corruption cleanup block

### DIFF
--- a/docs/FlagFix/FLAGFIX_037_043_TITLE_CORRUPTION_CLOSURE_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_037_043_TITLE_CORRUPTION_CLOSURE_INDEX.md
@@ -1,0 +1,83 @@
+# FlagFix 037-043 - Title Corruption Cleanup Closure Index
+
+Date: 2026-05-18
+
+## Scope Summary
+
+#FlagFix_037 through #FlagFix_043 completed the local CSL metadata cleanup for ASCII/hex-like title corruption artifacts.
+
+- #FlagFix_037 confirmed one EN metadata title corruption in `BA.AA.004` and corrected it on disk.
+- #FlagFix_038 created the corpus-wide inventory of suspicious title metadata artifacts.
+- #FlagFix_039 through #FlagFix_042 corrected EN title metadata in small evidence-backed batches.
+- #FlagFix_043 corrected the remaining PT title metadata artifacts after EN titles were stabilized.
+
+## PR Index
+
+- #130 / #FlagFix_037: recorded the confirmed `BA.AA.004` EN title corruption and correction.
+- #131 / #FlagFix_038: added the corpus-wide title corruption inventory and review CSV.
+- #132 / #FlagFix_039: recorded EN title correction batch 1.
+- #133 / #FlagFix_040: recorded EN title correction batch 2.
+- #134 / #FlagFix_041: recorded EN title correction batch 3.
+- #135 / #FlagFix_042: recorded the final EN title correction batch.
+- #136 / #FlagFix_043: recorded PT title corruption cleanup after EN stabilization.
+
+## Checkpoints
+
+- `checkpoint/flagfix-037-038-title-corruption-inventory-20260518`
+- `checkpoint/flagfix-039-en-title-correction-batch-1-20260518`
+- `checkpoint/flagfix-040-en-title-correction-batch-2-20260518`
+- `checkpoint/flagfix-041-en-title-correction-batch-3-20260518`
+- `checkpoint/flagfix-042-final-en-title-correction-20260518`
+- `checkpoint/flagfix-037-043-title-corruption-cleaned-20260518`
+
+## Final Audit Result
+
+Final suspicious title audit result:
+
+- checked: 748 identity files
+- EN hits: 0
+- PT hits: 0
+- total hits: 0
+
+The known ASCII/hex-like title metadata corruption inventory from #FlagFix_038 is closed.
+
+## Important Caveat
+
+The CSL metadata corrections were applied on disk under:
+
+- `pipeline/09-csl/*/meta/identity.json`
+
+However, `pipeline/09-csl` is ignored by Git in this workspace. That means the tracked PRs preserve the reports and review CSV evidence, not the actual CSL metadata diff.
+
+A future canonicalization or manifest strategy should decide how to preserve, verify, and replay these local CSL metadata corrections so they cannot be lost during workspace refresh, source regeneration, or migration.
+
+## Static Status
+
+Static artifacts are still stale and may still mirror old title metadata until regeneration.
+
+No build, pipeline, deploy, Netlify update, or Vitrine promotion was run during this cleanup block.
+
+Static regeneration and promotion should happen only in an approved follow-up batch, after review.
+
+## Next Recommended Options
+
+Option A: prepare a canonicalization/manifest strategy for local CSL metadata corrections.
+
+Option B: regenerate static only after approved batch closure.
+
+Option C: promote to Netlify/Vitrine only after reviewed static regeneration.
+
+Option D: continue unrelated low-risk UI/copy FlagFixes while keeping title metadata promotion separate.
+
+## No-Change Confirmations
+
+- Did not touch `/home/sanghop/axis/axis-niddhi-published`.
+- Did not update Netlify/Vitrine.
+- Did not run build, pipeline, or deploy.
+- Did not call DeepL.
+- Did not translate anything.
+- Did not modify CSL content in this closure sprint.
+- Did not modify static artifacts.
+- Did not modify metadata CSVs.
+- Did not modify `Translation_Control_Center.csv`.
+- Did not modify SP10/SP11 behavior.


### PR DESCRIPTION
## Summary

Adds #FlagFix_044: closure/index document for the #037–#043 title corruption cleanup block.

## Covers

- #037: confirmed EN title metadata corruption and corrected BA.AA.004 on disk
- #038: corpus-wide title corruption inventory
- #039–#042: EN title correction batches
- #043: PT title corruption cleanup

## Final audit result

- checked=748
- EN hits=0
- PT hits=0
- total suspicious title hits=0

## Important caveat

CSL metadata corrections were applied on disk in pipeline/09-csl/*/meta/identity.json.

pipeline/09-csl is ignored by Git in this workspace, so tracked PRs contain documentation and review CSV evidence, not the actual CSL metadata diff.

Future canonicalization/manifest strategy may need to decide how to preserve these local CSL corrections.

## Static status

Static artifacts still mirror old metadata until an approved static regeneration/promotion batch.

No build, pipeline, deploy, Netlify/Vitrine promotion, or Cloudflare configuration change was made.

## Files added

- docs/FlagFix/FLAGFIX_037_043_TITLE_CORRUPTION_CLOSURE_INDEX.md

## Safety

Documentation only.
No axis-niddhi-published changes.
No Netlify/Vitrine update.
No build/pipeline/deploy.
No DeepL call.
No translation.
No CSL content changes in this sprint.
No static artifact changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 behavior changes.