### PR TITLE
docs(flagfix): add CSL correction manifest draft

### DIFF
--- a/docs/FlagFix/FLAGFIX_046_CSL_CORRECTION_MANIFEST_DRAFT.md
+++ b/docs/FlagFix/FLAGFIX_046_CSL_CORRECTION_MANIFEST_DRAFT.md
@@ -1,0 +1,93 @@
+# FlagFix 046 - CSL Correction Manifest Draft
+
+Date: 2026-05-18
+
+## Scope
+
+This sprint created a tracked manifest draft for known CSL metadata corrections applied on disk during #FlagFix_028 and #FlagFix_037 through #FlagFix_043.
+
+No validator, apply script, `.gitignore` change, CSL edit, static edit, build, pipeline, deploy, DeepL call, or Vitrine promotion was performed.
+
+## Manifest
+
+Manifest path:
+
+- `review/csl-corrections/csl_metadata_corrections_manifest_v1.json`
+
+Manifest purpose:
+
+- preserve intended CSL metadata title corrections in tracked form;
+- make future read-only validation possible;
+- avoid relying only on ignored `pipeline/09-csl` workspace state.
+
+## Correction Count
+
+Corrections recorded: 25
+
+Breakdown:
+
+- #FlagFix_028: 1 correction
+- #FlagFix_037: 1 correction
+- #FlagFix_039: 5 corrections
+- #FlagFix_040: 5 corrections
+- #FlagFix_041: 5 corrections
+- #FlagFix_042: 3 corrections
+- #FlagFix_043: 5 corrections
+
+## Source FlagFixes Covered
+
+- #028: `LD.AA.000` PT title contamination cleanup.
+- #037: `BA.AA.004` EN title diacritic corruption cleanup.
+- #039: EN title correction batch 1.
+- #040: EN title correction batch 2.
+- #041: EN title correction batch 3.
+- #042: final EN title correction batch.
+- #043: PT title corruption cleanup.
+
+## Current Limitations
+
+The manifest is not an apply mechanism.
+
+No validator exists yet. This means the manifest is reviewable documentation/data, but it does not yet automatically compare current `pipeline/09-csl` values against expected corrected values.
+
+No apply script exists. This is intentional. Any future write-capable remediation must be reviewed after the manifest and read-only validator are accepted.
+
+## Next Recommended Sprint
+
+Suggested next sprint:
+
+`#FlagFix_047 - CSL correction manifest read-only validator`
+
+Recommended scope:
+
+- read the tracked manifest;
+- check that each referenced `identity.json` exists;
+- compare `json_path` current value to `new_value`;
+- report match/mismatch/missing/JSON error counts;
+- exit nonzero on mismatches;
+- do not write to CSL;
+- do not create an apply script.
+
+## JSON Validation
+
+The manifest was validated with:
+
+```bash
+python3 -m json.tool review/csl-corrections/csl_metadata_corrections_manifest_v1.json >/tmp/csl_manifest_v1.pretty.json
+```
+
+## No-Change Confirmations
+
+- Did not touch `/home/sanghop/axis/axis-niddhi-published`.
+- Did not update Netlify/Vitrine.
+- Did not run build, pipeline, or deploy.
+- Did not call DeepL.
+- Did not translate anything.
+- Did not modify CSL content.
+- Did not modify static artifacts.
+- Did not modify metadata CSVs.
+- Did not modify `Translation_Control_Center.csv`.
+- Did not modify SP10/SP11 behavior.
+- Did not change `.gitignore`.
+- Did not create a validator.
+- Did not create an apply script.

--- a/review/csl-corrections/csl_metadata_corrections_manifest_v1.json
+++ b/review/csl-corrections/csl_metadata_corrections_manifest_v1.json
@@ -1,0 +1,259 @@
+{
+  "manifest_version": "1.0",
+  "created_for": "FlagFix_046",
+  "created_date": "2026-05-18",
+  "scope": "CSL metadata title corrections applied on disk during FlagFix #028 and #037-#043",
+  "workspace_note": "pipeline/09-csl is ignored by Git; this manifest records intended corrections in tracked form.",
+  "corrections": [
+    {
+      "flagfix": "028",
+      "pdpn": "LD.AA.000",
+      "file": "pipeline/09-csl/LD.AA.000/meta/identity.json",
+      "json_path": "titles.pt",
+      "old_value": "Vivendo il Dhamma",
+      "new_value": "Vivendo o Dhamma",
+      "status": "applied_on_disk",
+      "evidence": "docs/FlagFix/FLAGFIX_028_PT_TITLE_LANGUAGE_CONTAMINATION_TRIAGE.md"
+    },
+    {
+      "flagfix": "037",
+      "pdpn": "BA.AA.004",
+      "file": "pipeline/09-csl/BA.AA.004/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Viparie1B987Ama Two Meanings",
+      "new_value": "Vipariṇāma Two Meanings",
+      "status": "applied_on_disk",
+      "evidence": "docs/FlagFix/FLAGFIX_037_EN_TITLE_DIACRITIC_CORRUPTION.md"
+    },
+    {
+      "flagfix": "039",
+      "pdpn": "BA.AA.001",
+      "file": "pipeline/09-csl/BA.AA.001/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Pali Suttas In Tipie1B9Adaka Direct Translations Are Wrong",
+      "new_value": "Pāli Suttās in Tipiṭaka – Direct Translations are Wrong",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_039_en_title_correction_batch_1.csv"
+    },
+    {
+      "flagfix": "039",
+      "pdpn": "BA.AA.005",
+      "file": "pipeline/09-csl/BA.AA.005/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Arammae1B987A Sensory Input Initiates Critical Processes",
+      "new_value": "Ārammaṇa (Sensory Input) Initiates Critical Processes",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_039_en_title_correction_batch_1.csv"
+    },
+    {
+      "flagfix": "039",
+      "pdpn": "BM.CC.006",
+      "file": "pipeline/09-csl/BM.CC.006/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Tae1B987Ha Result Of Sanna Giving Rise To Mind Made Vedana",
+      "new_value": "Taṇhā – Result of Saññā Giving Rise to Mind-Made Vedanā",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_039_en_title_correction_batch_1.csv"
+    },
+    {
+      "flagfix": "039",
+      "pdpn": "DS.DD.005",
+      "file": "pipeline/09-csl/DS.DD.005/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Sandie1B9Ade1B9Adhiko What Does It Mean",
+      "new_value": "Sandiṭṭhiko – What Does It Mean?",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_039_en_title_correction_batch_1.csv"
+    },
+    {
+      "flagfix": "039",
+      "pdpn": "IS.BB.004",
+      "file": "pipeline/09-csl/IS.BB.004/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Aniccae1B981 Viparie1B987Ami Annathabhavi A Critical Verse",
+      "new_value": "Aniccaṁ Vipariṇāmi Aññathābhāvi – A Critical Verse",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_039_en_title_correction_batch_1.csv"
+    },
+    {
+      "flagfix": "040",
+      "pdpn": "CH.AA.005",
+      "file": "pipeline/09-csl/CH.AA.005/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Rupa Dhamma Appae1B9Adigha Rupa And Namagotta Memories",
+      "new_value": "Rupa, Dhammā (Appaṭigha Rupa) and Nāmagotta (Memories)",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_040_en_title_correction_batch_2.csv"
+    },
+    {
+      "flagfix": "040",
+      "pdpn": "DS.DD.003",
+      "file": "pipeline/09-csl/DS.DD.003/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Mind Pleasing Things In The World Arise Via Pae1B9Adicca Samuppada",
+      "new_value": "“Mind-Pleasing Things” in the World Arise via Paṭicca Samuppāda",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_040_en_title_correction_batch_2.csv"
+    },
+    {
+      "flagfix": "040",
+      "pdpn": "DS.DD.007",
+      "file": "pipeline/09-csl/DS.DD.007/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Kama Sanna How To Bypass To Cultivate Satipae1B9Ade1B9Adhana",
+      "new_value": "Kāma Saññā – How to Bypass to Cultivate Satipaṭṭhāna",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_040_en_title_correction_batch_2.csv"
+    },
+    {
+      "flagfix": "040",
+      "pdpn": "ER.FF.004",
+      "file": "pipeline/09-csl/ER.FF.004/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Anapanasati Not About Breath Icchanae1B985Gala Sutta",
+      "new_value": "Ānāpānasati Not About Breath – Icchā­naṅga­la Sutta",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_040_en_title_correction_batch_2.csv"
+    },
+    {
+      "flagfix": "040",
+      "pdpn": "KD.DD.005",
+      "file": "pipeline/09-csl/KD.DD.005/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Kamma Are Done With Abhisae1B985Khara Types Of Abhisae1B985Khara",
+      "new_value": "Kamma are Done with Abhisaṅkhāra – Types of Abhisaṅkhāra",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_040_en_title_correction_batch_2.csv"
+    },
+    {
+      "flagfix": "041",
+      "pdpn": "KD.II.010",
+      "file": "pipeline/09-csl/KD.II.010/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Sensory Experience Pae1B9Adicca Samuppada And Pancupadanakkhandha",
+      "new_value": "Sensory Experience, Paṭicca Samuppāda, and pañcupādānakkhandha",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_041_en_title_correction_batch_3.csv"
+    },
+    {
+      "flagfix": "041",
+      "pdpn": "KD.JJ.010",
+      "file": "pipeline/09-csl/KD.JJ.010/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Namarupa In Vipaka Vinnae1B987A",
+      "new_value": "Nāmarupa in Vipāka Viññāṇa",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_041_en_title_correction_batch_3.csv"
+    },
+    {
+      "flagfix": "041",
+      "pdpn": "KD.JJ.011",
+      "file": "pipeline/09-csl/KD.JJ.011/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Namarupa In Pae1B9Adicca Samuppada",
+      "new_value": "Nāmarupa in Idappaccayātā Paṭicca Samuppāda",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_041_en_title_correction_batch_3.csv"
+    },
+    {
+      "flagfix": "041",
+      "pdpn": "PS.DD.004",
+      "file": "pipeline/09-csl/PS.DD.004/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Difference Between Dhamma And Sae1B985Khara",
+      "new_value": "Difference Between Dhammā and Saṅkhāra",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_041_en_title_correction_batch_3.csv"
+    },
+    {
+      "flagfix": "041",
+      "pdpn": "PS.GG.004",
+      "file": "pipeline/09-csl/PS.GG.004/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Sae1B985Khara An Introduction",
+      "new_value": "Saṅkhāra – An Introduction",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_041_en_title_correction_batch_3.csv"
+    },
+    {
+      "flagfix": "042",
+      "pdpn": "PS.II.011",
+      "file": "pipeline/09-csl/PS.II.011/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Namarupa Vinnae1B987A Dhamma Closely Related",
+      "new_value": "Nāmarupa, Viññāṇa, Dhammā – Closely Related",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_042_en_title_correction_final_batch.csv"
+    },
+    {
+      "flagfix": "042",
+      "pdpn": "TL.II.008",
+      "file": "pipeline/09-csl/TL.II.008/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Fooled By Distorted Sanna Sanjanati Origin Of Attachment Tae1B987Ha",
+      "new_value": "Fooled by Distorted Saññā (Sañjānāti) – Origin of Attachment (Taṇhā)",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_042_en_title_correction_final_batch.csv"
+    },
+    {
+      "flagfix": "042",
+      "pdpn": "TL.II.013",
+      "file": "pipeline/09-csl/TL.II.013/meta/identity.json",
+      "json_path": "titles.en",
+      "old_value": "Sanna Nidana Hi Papanca Sae1B985Kha Immoral Thoughts Based On Distorted Sanna",
+      "new_value": "Saññā Nidānā hi Papañca Saṅkhā – Immoral Thoughts Based on “Distorted Saññā”",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_042_en_title_correction_final_batch.csv"
+    },
+    {
+      "flagfix": "043",
+      "pdpn": "KD.DD.005",
+      "file": "pipeline/09-csl/KD.DD.005/meta/identity.json",
+      "json_path": "titles.pt",
+      "old_value": "Kamma já terminou o Abhisae1B985Khara Tipos de Abhisae1B985Khara",
+      "new_value": "Kamma é feito com Abhisaṅkhāra – Tipos de Abhisaṅkhāra",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_043_pt_title_corruption_cleanup.csv"
+    },
+    {
+      "flagfix": "043",
+      "pdpn": "KD.II.010",
+      "file": "pipeline/09-csl/KD.II.010/meta/identity.json",
+      "json_path": "titles.pt",
+      "old_value": "Experiência sensorial Pae1B9Adicca Samuppada e Pancupadanakkhandha",
+      "new_value": "Experiência sensorial, Paṭicca Samuppāda e Pañcupādānakkhandha",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_043_pt_title_corruption_cleanup.csv"
+    },
+    {
+      "flagfix": "043",
+      "pdpn": "KD.JJ.010",
+      "file": "pipeline/09-csl/KD.JJ.010/meta/identity.json",
+      "json_path": "titles.pt",
+      "old_value": "Namarupa em Vipaka Vinnae 1B987A",
+      "new_value": "Nāmarupa em Vipāka Viññāṇa",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_043_pt_title_corruption_cleanup.csv"
+    },
+    {
+      "flagfix": "043",
+      "pdpn": "TL.II.008",
+      "file": "pipeline/09-csl/TL.II.008/meta/identity.json",
+      "json_path": "titles.pt",
+      "old_value": "Enganado por Sanna Sanjanati Distorcido Origem do Vínculo Tae1B987Ha",
+      "new_value": "Enganado pela Saññā Distorcida (Sañjānāti) – Origem do Apego (Taṇhā)",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_043_pt_title_corruption_cleanup.csv"
+    },
+    {
+      "flagfix": "043",
+      "pdpn": "TL.II.013",
+      "file": "pipeline/09-csl/TL.II.013/meta/identity.json",
+      "json_path": "titles.pt",
+      "old_value": "Sanna Nidana Hi Papanca Sae1B985Kha Pensamentos imorais baseados em Sanna distorcido",
+      "new_value": "Saññā Nidānā hi Papañca Saṅkhā – Pensamentos imorais baseados em “Saññā Distorcida”",
+      "status": "applied_on_disk",
+      "evidence": "review/title-corruption/flagfix_043_pt_title_corruption_cleanup.csv"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds #FlagFix_046: a tracked manifest draft for CSL metadata corrections applied on disk during recent FlagFix batches.

## Files added

- review/csl-corrections/csl_metadata_corrections_manifest_v1.json
- docs/FlagFix/FLAGFIX_046_CSL_CORRECTION_MANIFEST_DRAFT.md

## Manifest coverage

The manifest records 25 known CSL metadata corrections:

- #028: 1 correction
- #037: 1 correction
- #039: 5 corrections
- #040: 5 corrections
- #041: 5 corrections
- #042: 3 corrections
- #043: 5 corrections

## Context

pipeline/09-csl is ignored by Git in this workspace.

This manifest records the intended CSL metadata corrections in tracked form, but does not yet provide a validator or apply script.

## Validation

- python3 -m json.tool passed for review/csl-corrections/csl_metadata_corrections_manifest_v1.json
- git diff --check passed

## Safety

Manifest/documentation only.
No validator created.
No apply script created.
No .gitignore change.
No CSL content changes in this sprint.
No static artifact changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 behavior changes.
No DeepL call.
No build/pipeline/deploy.
No Netlify/Vitrine update.
No axis-niddhi-published changes.