### PR TITLE
feat(flagfix): add CSL correction manifest validator

### DIFF
--- a/docs/FlagFix/FLAGFIX_047_CSL_CORRECTION_MANIFEST_VALIDATOR.md
+++ b/docs/FlagFix/FLAGFIX_047_CSL_CORRECTION_MANIFEST_VALIDATOR.md
@@ -1,0 +1,89 @@
+# FlagFix 047 - CSL Correction Manifest Validator
+
+Date: 2026-05-18
+
+## Scope
+
+This sprint added a read-only validator for the tracked CSL correction manifest created in #FlagFix_046.
+
+The validator compares manifest `new_value` entries against the current local CSL metadata under `pipeline/09-csl`.
+
+## Files
+
+Validator script:
+
+- `pipeline/scripts/tools/validate_csl_correction_manifest.py`
+
+Manifest path:
+
+- `review/csl-corrections/csl_metadata_corrections_manifest_v1.json`
+
+## Behavior
+
+The validator:
+
+- loads the tracked manifest JSON;
+- validates required top-level keys;
+- validates required correction fields;
+- supports `titles.en` and `titles.pt` JSON paths;
+- reads each target `identity.json`;
+- compares the current value to manifest `new_value`;
+- prints one status line per correction;
+- prints a concise summary;
+- does not write to CSL or any other project file.
+
+Status values:
+
+- `MATCH`
+- `MISMATCH`
+- `MISSING_FILE`
+- `MISSING_PATH`
+
+Exit codes:
+
+- `0`: all corrections match current local CSL metadata.
+- `1`: validation completed, but mismatches or missing entries were found.
+- `2`: invalid manifest or fatal manifest read error.
+
+## Actual Validation Result
+
+Command run:
+
+```bash
+python3 pipeline/scripts/tools/validate_csl_correction_manifest.py
+echo "exit_code=$?"
+```
+
+Result:
+
+```text
+summary: total=25 match=25 mismatch=0 missing_file=0 missing_path=0
+exit_code=0
+```
+
+This confirms that the current local CSL metadata matches the tracked correction manifest.
+
+## Next Recommended Sprint
+
+A future sprint may consider an apply script only after reviewing the manifest and validator behavior.
+
+Recommended next step before any apply script:
+
+- add a small negative-fixture test or documented dry-run mismatch example;
+- keep any future apply mode separate from this read-only validator;
+- continue avoiding `.gitignore` changes until CSL ownership is decided.
+
+## No-Change Confirmations
+
+- Did not create an apply script.
+- Did not modify CSL content.
+- Did not touch `/home/sanghop/axis/axis-niddhi-published`.
+- Did not update Netlify/Vitrine.
+- Did not run build, pipeline, or deploy.
+- Did not call DeepL.
+- Did not translate anything.
+- Did not modify static artifacts.
+- Did not modify metadata CSVs.
+- Did not modify `Translation_Control_Center.csv`.
+- Did not modify SP10/SP11 behavior.
+- Did not change `.gitignore`.

--- a/pipeline/scripts/tools/validate_csl_correction_manifest.py
+++ b/pipeline/scripts/tools/validate_csl_correction_manifest.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Read-only validator for the tracked CSL correction manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_MANIFEST = "review/csl-corrections/csl_metadata_corrections_manifest_v1.json"
+REQUIRED_TOP_LEVEL = ("manifest_version", "corrections")
+REQUIRED_CORRECTION_KEYS = ("flagfix", "pdpn", "file", "json_path", "new_value")
+SUPPORTED_JSON_PATHS = ("titles.en", "titles.pt")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate tracked CSL metadata corrections against local identity.json files."
+    )
+    parser.add_argument(
+        "--manifest",
+        default=DEFAULT_MANIFEST,
+        help=f"Path to correction manifest JSON. Default: {DEFAULT_MANIFEST}",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root used to resolve manifest and correction file paths. Default: cwd",
+    )
+    return parser.parse_args()
+
+
+def fatal(message: str) -> int:
+    print(f"ERROR: {message}", file=sys.stderr)
+    return 2
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError("manifest root must be an object")
+    return data
+
+
+def validate_manifest_shape(manifest: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for key in REQUIRED_TOP_LEVEL:
+        if key not in manifest:
+            errors.append(f"missing top-level key: {key}")
+
+    corrections = manifest.get("corrections")
+    if not isinstance(corrections, list):
+        errors.append("corrections must be a list")
+        return errors
+
+    for idx, correction in enumerate(corrections):
+        if not isinstance(correction, dict):
+            errors.append(f"corrections[{idx}] must be an object")
+            continue
+        for key in REQUIRED_CORRECTION_KEYS:
+            if key not in correction:
+                errors.append(f"corrections[{idx}] missing key: {key}")
+        json_path = correction.get("json_path")
+        if json_path is not None and json_path not in SUPPORTED_JSON_PATHS:
+            errors.append(f"corrections[{idx}] unsupported json_path: {json_path}")
+    return errors
+
+
+def resolve_json_path(data: dict[str, Any], json_path: str) -> tuple[bool, Any]:
+    current: Any = data
+    for part in json_path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False, None
+        current = current[part]
+    return True, current
+
+
+def validate_corrections(repo_root: Path, corrections: list[dict[str, Any]]) -> Counter[str]:
+    counts: Counter[str] = Counter()
+
+    for correction in corrections:
+        pdpn = str(correction["pdpn"])
+        json_path = str(correction["json_path"])
+        rel_file = str(correction["file"])
+        target = repo_root / rel_file
+
+        if not target.exists():
+            status = "MISSING_FILE"
+        else:
+            try:
+                data = json.loads(target.read_text(encoding="utf-8"))
+            except Exception as exc:  # noqa: BLE001 - fatal for this correction, not whole run.
+                status = "MISMATCH"
+                print(f"READ_ERROR | {pdpn} | {json_path} | {rel_file} | {exc}")
+                counts[status] += 1
+                continue
+
+            exists, current_value = resolve_json_path(data, json_path)
+            if not exists:
+                status = "MISSING_PATH"
+            elif current_value == correction["new_value"]:
+                status = "MATCH"
+            else:
+                status = "MISMATCH"
+
+        print(f"{status} | {pdpn} | {json_path} | {rel_file}")
+        counts[status] += 1
+
+    return counts
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_absolute():
+        manifest_path = repo_root / manifest_path
+
+    try:
+        manifest = load_manifest(manifest_path)
+    except Exception as exc:  # noqa: BLE001 - report as invalid manifest/fatal read.
+        return fatal(f"could not read manifest {manifest_path}: {exc}")
+
+    shape_errors = validate_manifest_shape(manifest)
+    if shape_errors:
+        for error in shape_errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+    corrections = manifest["corrections"]
+    counts = validate_corrections(repo_root, corrections)
+
+    total = len(corrections)
+    match = counts["MATCH"]
+    mismatch = counts["MISMATCH"]
+    missing_file = counts["MISSING_FILE"]
+    missing_path = counts["MISSING_PATH"]
+
+    print(
+        "summary: "
+        f"total={total} "
+        f"match={match} "
+        f"mismatch={mismatch} "
+        f"missing_file={missing_file} "
+        f"missing_path={missing_path}"
+    )
+
+    if mismatch or missing_file or missing_path:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds #FlagFix_047: a read-only validator for the tracked CSL correction manifest.

## Files added

- pipeline/scripts/tools/validate_csl_correction_manifest.py
- docs/FlagFix/FLAGFIX_047_CSL_CORRECTION_MANIFEST_VALIDATOR.md

## Validation result

Validator run against current local CSL:

- total=25
- match=25
- mismatch=0
- missing_file=0
- missing_path=0
- exit_code=0

## Exit code semantics

- 0: all manifest corrections match current local CSL
- 1: validator completed but mismatch/missing entries were found
- 2: invalid manifest or fatal read error

## Context

#FlagFix_046 created the tracked manifest:

- review/csl-corrections/csl_metadata_corrections_manifest_v1.json

This validator makes the manifest verifiable against the current local CSL without applying or modifying anything.

## Safety

Read-only validator only.
No apply script created.
No CSL content changes.
No .gitignore changes.
No static artifact changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 behavior changes.
No DeepL call.
No build/pipeline/deploy.
No Netlify/Vitrine update.
No axis-niddhi-published changes.

## Validation

- python3 -m py_compile pipeline/scripts/tools/validate_csl_correction_manifest.py passed
- git diff --check passed