### PR TITLE
docs(flagfix): preserve current Vitrine dirty state

### DIFF
--- a/docs/FlagFix/FLAGFIX_054_PRESERVE_CURRENT_VITRINE_DIRTY_STATE.md
+++ b/docs/FlagFix/FLAGFIX_054_PRESERVE_CURRENT_VITRINE_DIRTY_STATE.md
@@ -1,0 +1,109 @@
+# FlagFix 054 — Preserve Current Vitrine Dirty State Before Sync
+
+Date: 2026-05-19
+
+## Reason
+
+#FlagFix_053 ran only an `rsync` dry run. Before any real promotion sync, the published Vitrine workspace was found to already be dirty. This sprint preserves that pre-sync state so there is a rollback/reference point before any future overwrite.
+
+No real sync was run in this sprint.
+
+## Production Repo State
+
+Production repo:
+
+- path: `/home/sanghop/axis/axis-niddhi-production`
+- branch/status: `main...origin/main`
+- #FlagFix_053 merged at checkpoint: `checkpoint/flagfix-053-vitrine-promotion-dry-run-20260519`
+
+## Published Workspace Dirty State
+
+Published workspace:
+
+- path: `/home/sanghop/axis/axis-niddhi-published`
+- branch/status: `main...origin/main`
+- modified files: 116
+- untracked files: 0
+- modified area: `pipeline/13-static-site/**`
+
+Diff stat summary:
+
+- `116 files changed`
+- `12612 insertions(+)`
+- `1181 deletions(-)`
+
+Representative modified paths:
+
+- `pipeline/13-static-site/archive.html`
+- `pipeline/13-static-site/build_meta.json`
+- `pipeline/13-static-site/index.json`
+- `pipeline/13-static-site/search_index.json`
+- `pipeline/13-static-site/pages/LD.AA.000/index.html`
+- many `pipeline/13-static-site/pages/KD.*/*/index.html`
+- many `pipeline/13-static-site/pages/LD.*/*/index.html`
+
+## Preservation Files
+
+Snapshot base:
+
+- `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609`
+
+Files created outside the published Git tree:
+
+- `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609_status.txt`
+- `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609_diff_stat.txt`
+- `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609_name_status.txt`
+- `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609.patch`
+- `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609_pipeline_13_static_site_snapshot.tar.gz`
+- `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609_sha256.txt`
+
+Observed sizes:
+
+- patch: 3.3M
+- diff stat: 7.4K
+- name-status: 6.0K
+- status: 6.1K
+- tarball snapshot: 719M
+- sha256 file: 366B
+
+## SHA256
+
+```text
+e9dad6d238b561230351d141e1aba619636279abb64a890789be525bd01dd782  /home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609.patch
+9d1523a308bd44fb28783c5df1c7f49a97e919ee31005bd9c5f4ee3569ae45a7  /home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609_pipeline_13_static_site_snapshot.tar.gz
+```
+
+## Commit Policy
+
+No commit was created inside `/home/sanghop/axis/axis-niddhi-published`.
+
+The published workspace remains dirty exactly so the operator can decide the next preservation/promotion move explicitly.
+
+## Recommendation
+
+Before any real sync, choose one of these paths:
+
+1. Commit, stash, or otherwise intentionally preserve the current dirty published state inside `/home/sanghop/axis/axis-niddhi-published`.
+2. If the external snapshot is accepted as sufficient rollback evidence, proceed to a future real sync sprint with explicit approval.
+3. If there is uncertainty about the dirty state, inspect the 116 modified paths before syncing over them.
+
+Recommended next sprint:
+
+- #FlagFix_055 should either formalize the published dirty state handling or perform the approved real sync only after the operator confirms this snapshot is sufficient.
+
+## Non-Actions
+
+This sprint did not:
+
+- run real `rsync`;
+- copy or sync production static into published;
+- deploy;
+- modify production static;
+- run build or pipeline;
+- call DeepL;
+- translate anything;
+- modify CSL;
+- modify `Translation_Control_Center.csv`;
+- modify SP10/SP11;
+- change `.gitignore`;
+- commit inside `/home/sanghop/axis/axis-niddhi-published`.


### PR DESCRIPTION
## Summary

Adds #FlagFix_054: preserves the current dirty state of the Netlify/Vitrine workspace before any real promotion sync.

## Reason

#FlagFix_053 ran only an rsync dry-run and found that /home/sanghop/axis/axis-niddhi-published was already dirty before any real sync.

Before running a real rsync, the current Vitrine state was preserved externally for rollback/review.

## Preserved state

Published repo:

- branch/status: main...origin/main
- modified files: 116
- untracked files: 0
- affected area: pipeline/13-static-site/**

## Snapshot artifacts

Base:

- /home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609

Patch:

- /home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609.patch

Tarball:

- /home/sanghop/axis/vitrine-safety-snapshots/flagfix_054_published_dirty_state_20260519_020609_pipeline_13_static_site_snapshot.tar.gz

SHA256:

- patch: e9dad6d238b561230351d141e1aba619636279abb64a890789be525bd01dd782
- tarball: 9d1523a308bd44fb28783c5df1c7f49a97e919ee31005bd9c5f4ee3569ae45a7

## Files added

- docs/FlagFix/FLAGFIX_054_PRESERVE_CURRENT_VITRINE_DIRTY_STATE.md

## Safety

No real rsync was run.
No files were copied or synced from production static to published.
No deploy.
No production static changes.
No build/pipeline run.
No DeepL call.
No translation.
No CSL changes.
No TCC changes.
No SP10/SP11 changes.
No .gitignore changes.
No commit was made inside axis-niddhi-published.