### PR TITLE
docs(flagfix): add Vitrine deployment readiness final check

### DIFF
--- a/docs/FlagFix/FLAGFIX_066_VITRINE_DEPLOYMENT_READINESS_FINAL_CHECK.md
+++ b/docs/FlagFix/FLAGFIX_066_VITRINE_DEPLOYMENT_READINESS_FINAL_CHECK.md
@@ -1,0 +1,146 @@
+# FlagFix 066 - Vitrine Deployment Readiness Final Check
+
+Date: 2026-05-19
+
+## Context
+
+Latest checkpoint:
+
+- `checkpoint/flagfix-065-close-superseded-pr155-20260519`
+
+This final check verifies that the approved Vitrine payload is ready for an explicit deployment decision. This sprint did not deploy, push, build, run pipeline steps, sync/copy files, call DeepL, translate, modify CSL, modify metadata CSVs, modify TCC/SP10/SP11, change `.gitignore`, modify `axis-niddhi-published`, or modify production static.
+
+## PR State
+
+PR #155:
+
+- URL: `https://github.com/matikamata/axis-niddhi/pull/155`
+- State: `CLOSED`
+- Head: `flagfix-062-approved-vitrine-payload`
+- Base: `main`
+- Result: superseded and closed; must not be merged.
+
+PR #158:
+
+- URL: `https://github.com/matikamata/axis-niddhi/pull/158`
+- State: `MERGED`
+- Head: `flagfix-064-static-payload-only-vitrine-update`
+- Base: `main`
+- Merged at: `2026-05-19T07:35:49Z`
+- Result: safe replacement PR is already merged.
+
+## Repository State
+
+Production repo:
+
+- Path: `/home/sanghop/axis/axis-niddhi-production`
+- Branch/status: `main...origin/main`
+- HEAD: `5b1a3a36`
+- Checkpoint tag present: `checkpoint/flagfix-065-close-superseded-pr155-20260519`
+
+Published repo:
+
+- Path: `/home/sanghop/axis/axis-niddhi-published`
+- Branch/status: `main...origin/main [ahead 1]`
+- Working tree: clean
+- Local Vitrine commit still present: `92f4c298f17008f4022c0267f1e64af14a1742a1`
+- Commit message: `build(vitrine): sync static payload after title corrections`
+- Remote: `https://github.com/matikamata/axis-niddhi.git`
+
+## Static Parity
+
+Compared:
+
+- `/home/sanghop/axis/axis-niddhi-production/pipeline/13-static-site`
+- `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site`
+
+Result:
+
+- `diff -qr` output lines: `0`
+- Production static and published static are identical.
+
+## String Checks
+
+Stale strings checked in production static:
+
+- `Vivendo il Dhamma`
+- `Viparie1B987Ama Two Meanings`
+- `pending translation / pendente de tradução`
+
+Result:
+
+- No stale string hits found.
+
+Corrected strings checked in production static:
+
+- `Vivendo o Dhamma`
+- `Vipariṇāma Two Meanings`
+- `Awaiting translation / Aguardando tradução`
+
+Result:
+
+- Corrected strings are present in expected static artifacts, including `index.json`, `search_index.json`, affected pages, and `archive.html`.
+
+## Bodhi Asset
+
+Compared asset:
+
+- `/home/sanghop/axis/axis-niddhi-production/pipeline/13-static-site/assets/BodhiCircuitLeaf.png`
+- `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site/assets/BodhiCircuitLeaf.png`
+
+Result:
+
+- Production hash: `92437a1aba75f9b6fb0d16f8598e1b0902a08c6c513d9014ac295d29848e49c7`
+- Published hash: `92437a1aba75f9b6fb0d16f8598e1b0902a08c6c513d9014ac295d29848e49c7`
+- Hashes match.
+
+## Netlify Publish Directory
+
+Published repo `netlify.toml`:
+
+```toml
+[build]
+  command = ""
+  publish = "pipeline/13-static-site"
+  ignore = "exit 0"
+
+[build.environment]
+  PYTHON_VERSION = "3.10"
+```
+
+Result:
+
+- Netlify publish directory: `pipeline/13-static-site`
+- Directory exists: `publish_dir_exists=yes`
+
+## Readiness Recommendation
+
+Recommendation: READY for deployment decision.
+
+All final readiness checks passed:
+
+- PR #155 is closed.
+- PR #158 is merged.
+- Production and published static payloads are identical.
+- Stale strings are absent.
+- Corrected strings are present.
+- Approved Bodhi asset matches by SHA256.
+- Netlify publish directory is confirmed and exists.
+
+This sprint still performed no deployment. Any actual Netlify/Vitrine deployment should remain a separate explicit operator-approved action.
+
+## Explicit Non-Actions
+
+- No deploy.
+- No push.
+- No build or pipeline run.
+- No DeepL call.
+- No translation.
+- No CSL modification.
+- No metadata CSV modification.
+- No `Translation_Control_Center.csv` modification.
+- No SP10/SP11 modification.
+- No sync/copy.
+- No `.gitignore` change.
+- No `axis-niddhi-published` modification.
+- No production static modification.


### PR DESCRIPTION
## Summary

Adds #FlagFix_066: final readiness check before Vitrine deployment decision.

## Results

- PR #155: CLOSED
- PR #158: MERGED
- published repo: main...origin/main [ahead 1]
- published working tree: clean
- published local commit: 92f4c29 present
- production vs published static diff: 0 lines
- stale strings: absent
- corrected strings: present
- Bodhi asset hash matches production and published
- Netlify publish directory: pipeline/13-static-site
- publish_dir_exists: yes

## Recommendation

READY for deployment decision.

No deployment was performed in this sprint.

## Safety

No deploy.
No push.
No build/pipeline run.
No DeepL call.
No translation.
No sync/copy.
No CSL changes.
No static changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.
No axis-niddhi-published changes.