### PR TITLE
feat(flagfix): add LABZ ambient side layer source MVP

### DIFF
--- a/docs/FlagFix/FLAGFIX_071_LABZ_AMBIENT_SIDE_LAYER_SOURCE_MVP.md
+++ b/docs/FlagFix/FLAGFIX_071_LABZ_AMBIENT_SIDE_LAYER_SOURCE_MVP.md
@@ -1,0 +1,153 @@
+# FlagFix 071 - LABZ Ambient Side Layer Source MVP
+
+Date: 2026-05-19
+
+## Context
+
+#FlagFix_070 audited the LABZ ambient side layer concept and recommended: `GO WITH GUARDS`.
+
+This sprint implements the smallest source-only MVP:
+
+- inert markup in `pipeline/13-ssg/templates/base.html`;
+- CSS-only placeholder visuals in `pipeline/13-ssg/static/css/style.css`;
+- no JavaScript changes;
+- no generated static output changes.
+
+## Files Changed
+
+- `pipeline/13-ssg/templates/base.html`
+- `pipeline/13-ssg/static/css/style.css`
+- `docs/FlagFix/FLAGFIX_071_LABZ_AMBIENT_SIDE_LAYER_SOURCE_MVP.md`
+
+## LABZ Activation Mechanism
+
+LABZ continues to be controlled by the existing stardust theme state:
+
+- Active selector: `body[data-theme="stardust"]`
+- Toggle function: `toggleLabz()` in `pipeline/13-ssg/static/js/main.js`
+- No JavaScript was changed for this MVP.
+
+The ambient layer is hidden by default and becomes visible only when stardust mode is active on sufficiently wide screens.
+
+## Markup Summary
+
+Added a decorative layer near the top of the body, outside `<main>`:
+
+- `.labz-ambient-layer`
+- `.labz-ambient-side-left`
+- `.labz-ambient-side-right`
+- six `.labz-ambient-motif` placeholder elements
+
+The layer is inert:
+
+- `aria-hidden="true"`
+- no links;
+- no buttons;
+- no inputs;
+- no focusable elements.
+
+## CSS Behavior Summary
+
+The CSS:
+
+- keeps `.labz-ambient-layer` hidden by default;
+- shows it only under `body[data-theme="stardust"]`;
+- positions it fixed outside the main reading frame;
+- keeps `main` above the decorative layer with `z-index: 1`;
+- uses subtle abstract botanical placeholder motifs;
+- uses CSS only;
+- does not require final image assets yet;
+- does not affect layout or text flow.
+
+The implementation intentionally avoids final flora/fauna imagery in this sprint. The current shapes are placeholders for future visual direction.
+
+## Accessibility Guards
+
+Accessibility guardrails included:
+
+- `aria-hidden="true"` on the decorative layer;
+- `pointer-events: none`;
+- no interactive descendants;
+- no focusable elements;
+- no semantic content;
+- no text content inside the motifs.
+
+## Mobile And Print Guards
+
+Mobile/narrow viewport behavior:
+
+- Ambient layer is only enabled inside `@media (min-width: 1101px)`.
+- It remains hidden on narrower screens.
+
+Print behavior:
+
+- `.labz-ambient-layer` was added to the existing print exclusion list.
+- It is hidden with `display: none !important` in print.
+
+## Reduced-Motion Guard
+
+The placeholder movement is only enabled under:
+
+```css
+@media (prefers-reduced-motion: no-preference)
+```
+
+Users requesting reduced motion receive the static decorative state.
+
+## No-Claims Confirmation
+
+This MVP adds decorative ambient visuals only.
+
+No claim language was added to source UI, code comments, or visible copy. The feature does not describe or promise health, study, attention, learning, performance, or wellbeing effects.
+
+## Validation Results
+
+Path scope before report:
+
+```text
+pipeline/13-ssg/static/css/style.css
+pipeline/13-ssg/templates/base.html
+PATH_SCOPE_OK
+```
+
+Forbidden claim language scan on source diff:
+
+```text
+NO_FORBIDDEN_CLAIM_LANGUAGE
+```
+
+## No Static Regeneration
+
+No build or SSG regeneration was run.
+
+`pipeline/13-static-site/**` was not modified.
+
+## Recommendation
+
+Next recommended sprint:
+
+- `#FlagFix_072 - LABZ ambient side layer visual asset design`
+
+Suggested scope:
+
+- design/select final decorative visual assets;
+- keep assets compressed and decorative;
+- preserve the existing source-only guards;
+- do not regenerate static until a later approved sprint.
+
+## Explicit Non-Actions
+
+- No final images were created.
+- No JavaScript was modified.
+- No generated static output was modified.
+- No build or pipeline run.
+- No deploy.
+- No Netlify upload.
+- No push to `main`.
+- No DeepL call.
+- No translation.
+- No CSL modification.
+- No metadata CSV modification.
+- No `Translation_Control_Center.csv` modification.
+- No SP10/SP11 modification.
+- No `axis-niddhi-published` modification.

--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -788,6 +788,7 @@ footer { margin-top: 4.5rem; font-size: 0.85rem; opacity: 0.65; text-align: cent
   #reading-progress-hook, #ai-assistant-hook,
   .digestibility-suggestion, .silent-pause-block,
   #search-form, #search-results, #print-modal, #print-modal-overlay, #labz-banner,
+  .labz-ambient-layer,
   iframe, .youtube-wrapper, .video-container { display: none !important; }
 
   /* ── YouTube Print Marker ── */
@@ -1028,6 +1029,8 @@ body[data-theme="stardust"] {
 }
 
 body[data-theme="stardust"] main {
+  position: relative;
+  z-index: 1;
   box-shadow:
     0 0 0 1px rgba(0, 255, 65, 0.12),
     0 0 40px rgba(0, 255, 65, 0.04);
@@ -1103,6 +1106,110 @@ body[data-theme="stardust"] #labz-banner {
   opacity: 1;
   transform: none;
   pointer-events: auto;
+}
+
+/* 7. LABZ ambient side layer — decorative, inert, outside reading flow */
+.labz-ambient-layer {
+  display: none;
+  pointer-events: none;
+}
+
+@media (min-width: 1101px) {
+  body[data-theme="stardust"] .labz-ambient-layer {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    overflow: hidden;
+  }
+
+  body[data-theme="stardust"] .labz-ambient-side {
+    position: fixed;
+    top: 6rem;
+    bottom: 5rem;
+    width: 132px;
+    pointer-events: none;
+  }
+
+  body[data-theme="stardust"] .labz-ambient-side-left {
+    left: max(1rem, calc((100vw - 840px) / 2 - 172px));
+  }
+
+  body[data-theme="stardust"] .labz-ambient-side-right {
+    right: max(1rem, calc((100vw - 840px) / 2 - 172px));
+  }
+
+  body[data-theme="stardust"] .labz-ambient-motif {
+    position: absolute;
+    display: block;
+    width: 56px;
+    height: 92px;
+    border: 1px solid rgba(0, 255, 65, 0.18);
+    border-radius: 72% 6% 72% 6%;
+    background:
+      linear-gradient(135deg, rgba(0, 255, 65, 0.12), rgba(0, 230, 118, 0.02) 58%, transparent 60%),
+      linear-gradient(90deg, transparent 47%, rgba(0, 255, 65, 0.16) 49%, transparent 52%);
+    box-shadow: 0 0 20px rgba(0, 255, 65, 0.035);
+    opacity: 0.38;
+    transform-origin: 50% 90%;
+  }
+
+  body[data-theme="stardust"] .labz-ambient-motif-1 {
+    top: 4%;
+    left: 28px;
+    transform: rotate(-18deg) scale(0.82);
+  }
+
+  body[data-theme="stardust"] .labz-ambient-motif-2 {
+    top: 38%;
+    left: 58px;
+    transform: rotate(14deg) scale(1.04);
+  }
+
+  body[data-theme="stardust"] .labz-ambient-motif-3 {
+    bottom: 6%;
+    left: 18px;
+    transform: rotate(-8deg) scale(0.9);
+  }
+
+  body[data-theme="stardust"] .labz-ambient-motif-4 {
+    top: 10%;
+    right: 24px;
+    transform: rotate(18deg) scale(0.86);
+  }
+
+  body[data-theme="stardust"] .labz-ambient-motif-5 {
+    top: 44%;
+    right: 58px;
+    transform: rotate(-14deg) scale(1);
+  }
+
+  body[data-theme="stardust"] .labz-ambient-motif-6 {
+    bottom: 4%;
+    right: 18px;
+    transform: rotate(10deg) scale(0.94);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    body[data-theme="stardust"] .labz-ambient-motif {
+      animation: labzAmbientFloat 12s ease-in-out infinite alternate;
+    }
+
+    body[data-theme="stardust"] .labz-ambient-motif:nth-child(2) {
+      animation-duration: 15s;
+      animation-delay: -4s;
+    }
+
+    body[data-theme="stardust"] .labz-ambient-motif:nth-child(3) {
+      animation-duration: 18s;
+      animation-delay: -7s;
+    }
+  }
+}
+
+@keyframes labzAmbientFloat {
+  from { margin-top: 0; }
+  to { margin-top: 12px; }
 }
 
 /* ── END FF-013 ── */

--- a/pipeline/13-ssg/templates/base.html
+++ b/pipeline/13-ssg/templates/base.html
@@ -18,6 +18,20 @@
 <!-- FF-014: Reading Progress Bar -->
 <div id="reading-progress" aria-hidden="true"></div>
 
+<!-- FF-071: Decorative LABZ ambient side layer; inert and hidden unless stardust is active. -->
+<div class="labz-ambient-layer" aria-hidden="true">
+    <div class="labz-ambient-side labz-ambient-side-left">
+        <span class="labz-ambient-motif labz-ambient-motif-1"></span>
+        <span class="labz-ambient-motif labz-ambient-motif-2"></span>
+        <span class="labz-ambient-motif labz-ambient-motif-3"></span>
+    </div>
+    <div class="labz-ambient-side labz-ambient-side-right">
+        <span class="labz-ambient-motif labz-ambient-motif-4"></span>
+        <span class="labz-ambient-motif labz-ambient-motif-5"></span>
+        <span class="labz-ambient-motif labz-ambient-motif-6"></span>
+    </div>
+</div>
+
     <!-- FEATURE 1: Floating Navigation (Left) -->
     <div class="floating-utilities" style="left: 1.2rem; right: auto;">
         <a href="{{ relative_root }}index.html" class="utility-pill" title="Home" style="text-decoration: none; font-size: 1.15rem; background: none; border: none; padding: 0.35rem 0.6rem;">


### PR DESCRIPTION
## Summary

Adds #FlagFix_071: a source-only LABZ ambient side layer MVP.

## Scope

Changed source files:

- `pipeline/13-ssg/templates/base.html`
- `pipeline/13-ssg/static/css/style.css`

Adds report:

- `docs/FlagFix/FLAGFIX_071_LABZ_AMBIENT_SIDE_LAYER_SOURCE_MVP.md`

## Behavior

- Active only under `body[data-theme="stardust"]`
- Decorative ambient side layer outside main reading flow
- CSS-only placeholder visuals
- No final images yet
- No generated static output

## Guards

- `aria-hidden="true"`
- `pointer-events: none`
- no focusable elements
- hidden on mobile/narrow viewports
- hidden in print
- respects `prefers-reduced-motion`
- no medical, therapeutic, cognitive, subliminal, healing, wellness, or performance claims

## Safety

No build/pipeline run.
No generated static changes.
No deploy.
No Netlify upload.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No axis-niddhi-published changes.
