### PR TITLE
docs(flagfix): audit Vitrine root CTA parity

### DIFF
--- a/docs/FlagFix/FLAGFIX_079_NETLIFY_CLOUDFLARE_SURFACE_PARITY_AUDIT.md
+++ b/docs/FlagFix/FLAGFIX_079_NETLIFY_CLOUDFLARE_SURFACE_PARITY_AUDIT.md
@@ -1,0 +1,249 @@
+# FlagFix 079 - Netlify/Cloudflare surface parity audit
+
+Date: 2026-05-19
+
+## Why This Audit Was Opened
+
+The public Netlify Vitrine is online at:
+
+- `https://niddhi.netlify.app/`
+
+The public Cloudflare experimental surface is online at:
+
+- `https://niddhi.pages.dev/`
+
+Concern: the Netlify public root appeared to lack the `CONTRIBUTE` CTA that exists in the approved static payload and on Cloudflare.
+
+Policy context:
+
+- Cloudflare is the test/homologation/experimental surface.
+- Netlify is the stable approved Vitrine.
+- Once a payload is approved, Netlify should be an exact copy of the approved static payload, not a reduced or older surface.
+
+## Repository State
+
+Production repo:
+
+- Path: `/home/sanghop/axis/axis-niddhi-production`
+- Status: `main...origin/main`
+- Current head includes `checkpoint/flagfix-078-labz-preview-closure-bodhi-asset-20260519`.
+
+Published repo:
+
+- Path: `/home/sanghop/axis/axis-niddhi-published`
+- Status: `main...origin/main [ahead 1]`
+- Head: `92f4c29 build(vitrine): sync static payload after title corrections`
+- `netlify.toml` publish directory: `pipeline/13-static-site`
+
+No repository files were changed during inspection except this report.
+
+## Local Static Parity
+
+Compared:
+
+- `axis-niddhi-production/pipeline/13-static-site`
+- `axis-niddhi-published/pipeline/13-static-site`
+
+Result:
+
+- Diff count: `753` lines from `diff -qr`
+
+Interpretation:
+
+- Current production static has moved past the last published local payload because #FlagFix_077 and #FlagFix_078 added LABZ preview/static changes and restored the corrected Bodhi asset in production.
+- The published local payload remains the previously approved Vitrine payload from the title/static correction block.
+- This means current production and local published are not expected to be byte-identical after #077/#078.
+
+First diff examples:
+
+- `archive.html` differs
+- `assets/labz` exists only in production
+- `build_meta.json` differs
+- `css/style.css` differs
+- generated page HTML differs across many pages
+
+## Local CONTRIBUTE Search
+
+Focused local surface files:
+
+- `index.html`
+- `welcome.html`
+- `archive.html`
+- `contribute.html`
+
+Local production static:
+
+- `welcome.html` contains:
+  - `CONTRIBUTE`
+  - `COLABORAR`
+- `contribute.html` exists and contains `Contribute / Colaborar`.
+- `index.html` does not contain the CTA.
+- `archive.html` does not contain the CTA.
+
+Local published static:
+
+- `welcome.html` contains:
+  - `CONTRIBUTE`
+  - `COLABORAR`
+- `contribute.html` exists and contains `Contribute / Colaborar`.
+- `index.html` does not contain the CTA.
+- `archive.html` does not contain the CTA.
+
+Local redirect rule in both production and published payloads:
+
+```text
+/ /welcome 302
+```
+
+## Public HTTP Status Summary
+
+Cloudflare:
+
+- `https://niddhi.pages.dev/`
+  - `302` to `/welcome`
+  - final `200`
+- `https://niddhi.pages.dev/archive.html`
+  - `308` to `/archive`
+  - final `200`
+
+Netlify:
+
+- `https://niddhi.netlify.app/`
+  - `200`
+  - no observed redirect to `/welcome`
+- `https://niddhi.netlify.app/archive.html`
+  - `200`
+
+## Public CONTRIBUTE Search
+
+Public root/archive files fetched into:
+
+- `/tmp/flagfix_079_public_surface/`
+
+Counts:
+
+| Public file | CONTRIBUTE/COLABORAR hits | ENTER ARCHIVE hits | Corrected title/status hits | Stale string hits |
+| --- | ---: | ---: | ---: | ---: |
+| `cloudflare_root.html` | 2 | 2 | 0 | 0 |
+| `cloudflare_archive.html` | 0 | 0 | 442 | 0 |
+| `netlify_root.html` | 0 | 2 | 0 | 0 |
+| `netlify_archive.html` | 0 | 0 | 442 | 0 |
+
+Additional direct checks:
+
+- `https://niddhi.netlify.app/welcome` contains `CONTRIBUTE` and `COLABORAR`.
+- `https://niddhi.netlify.app/welcome.html` contains `CONTRIBUTE` and `COLABORAR`.
+- `https://niddhi.netlify.app/contribute.html` exists and contains `Contribute / Colaborar`.
+- `https://niddhi.pages.dev/welcome` contains `CONTRIBUTE` and `COLABORAR`.
+- `https://niddhi.pages.dev/contribute.html` exists and contains `Contribute / Colaborar`.
+
+Conclusion:
+
+- Netlify does include the contribute surface.
+- Netlify public root does not show it because the root is serving an index-style page without the CTA rather than redirecting to `/welcome`.
+- Cloudflare public root does show it because Cloudflare redirects `/` to `/welcome`.
+
+## Public Cloudflare vs Netlify Diff Summary
+
+Root comparison:
+
+- `cloudflare_root.html` vs `netlify_root.html`
+- Diff length: `140` lines
+
+Archive comparison:
+
+- `cloudflare_archive.html` vs `netlify_archive.html`
+- Diff length: `12796` lines
+
+Important root difference:
+
+- Cloudflare root content is equivalent to the current `welcome.html` surface and includes `CONTRIBUTE`.
+- Netlify root content is an older/index-style surface and omits `CONTRIBUTE`.
+
+## Public Netlify vs Local Published
+
+Local published surface files:
+
+- `index.html`: exists, `7558` bytes
+- `welcome.html`: exists, `7015` bytes
+- `archive.html`: exists, `507209` bytes
+
+Comparisons:
+
+- Local published `welcome.html` vs public Netlify root: `140` diff lines
+- Local published `index.html` vs public Netlify root: `20` diff lines
+- Local published `archive.html` vs public Netlify archive: `12780` diff lines
+
+Interpretation:
+
+- Public Netlify root most closely resembles local `index.html`, not local `welcome.html`.
+- Public Netlify archive is not byte-identical to local published archive.
+- Public Netlify therefore does not currently match the local published payload exactly.
+
+## Corrected/Stale String Checks
+
+Public corrected strings:
+
+- Cloudflare archive contains corrected title/status strings.
+- Netlify archive contains corrected title/status strings.
+
+Public stale strings:
+
+- No hits for:
+  - `Vivendo il Dhamma`
+  - `Viparie1B987Ama Two Meanings`
+  - `pending translation / pendente de tradução`
+
+This suggests the title/static correction block has reached both public surfaces, even though root routing/surface parity is not aligned.
+
+## Root Cause Hypothesis
+
+Most likely:
+
+1. The local approved payload contains `CONTRIBUTE` in `welcome.html` and contains `contribute.html`.
+2. Cloudflare publicly redirects `/` to `/welcome`, so the CTA appears on the root URL.
+3. Netlify publicly serves `/` as an index-style page that does not contain the CTA.
+4. Netlify public is not an exact byte match for the local published payload; either:
+   - the public Netlify deploy is not the exact local published package, or
+   - Netlify routing is not applying the local `_redirects` rule as expected, or
+   - the root `index.html`/`welcome.html` split is structurally fragile for Netlify.
+
+Not supported by the evidence:
+
+- The local approved payload lacks `CONTRIBUTE`.
+- The `contribute.html` page is absent from Netlify.
+- Cloudflare has a branch-only CTA that never reached local static.
+
+## Recommendation
+
+Open a follow-up FlagFix before any further upload/deploy:
+
+`#FlagFix_080 — Netlify root routing and CONTRIBUTE CTA parity plan`
+
+Recommended focus:
+
+- Decide whether Netlify root should:
+  - force redirect `/` to `/welcome`, or
+  - make `index.html` the canonical welcome surface and include `CONTRIBUTE` there too.
+- Verify why Netlify public root ignores or bypasses the local `_redirects` expectation.
+- Verify whether the deployed Netlify payload is exactly the package expected from #FlagFix_068/#069.
+- Do not upload another package until this root routing decision is explicit.
+
+If the desired stable Vitrine behavior is "root must show the CTA," the lowest-risk product fix may be to make `index.html` and `welcome.html` intentionally aligned, rather than depending on host-specific root redirect behavior.
+
+## Explicit Non-Actions
+
+- No deploy.
+- No Netlify upload.
+- No push.
+- No build/pipeline run.
+- No DeepL call.
+- No translation.
+- No CSL changes.
+- No metadata CSV changes.
+- No `Translation_Control_Center.csv` changes.
+- No SP10/SP11 changes.
+- No sync/copy.
+- No `.gitignore` changes.
+- No `/home/sanghop/axis/axis-niddhi-published` changes.
+- No production static changes.

--- a/docs/FlagFix/FLAGFIX_080_NETLIFY_ROOT_ROUTING_CONTRIBUTE_PARITY_PLAN.md
+++ b/docs/FlagFix/FLAGFIX_080_NETLIFY_ROOT_ROUTING_CONTRIBUTE_PARITY_PLAN.md
@@ -1,0 +1,281 @@
+# FlagFix 080 - Netlify root routing and CONTRIBUTE CTA parity plan
+
+Date: 2026-05-19
+
+## Summary of #079 Findings
+
+#FlagFix_079 established that the `CONTRIBUTE` / `COLABORAR` CTA is present in the approved local payload, but it does not appear on the Netlify public root URL.
+
+Key findings carried forward:
+
+- Local published payload contains `CONTRIBUTE` in `welcome.html`.
+- Local published payload contains `contribute.html`.
+- Local `index.html` does not contain the contribution CTA.
+- Cloudflare public root `/` redirects to `/welcome`, so the root surface shows the CTA.
+- Netlify public root `/` serves an index-style page directly, so the CTA is absent there.
+- Netlify `/welcome`, `/welcome.html`, and `/contribute.html` do contain the contribution surface.
+
+Conclusion:
+
+- The issue is root routing and landing-surface parity.
+- The issue is not the absence of the contribution page.
+
+## Root Cause
+
+The current Vitrine structure relies on a host-level redirect for the desired landing experience:
+
+- `_redirects` contains `/ /welcome 302`
+- `welcome.html` is the surface with the contribution CTA
+- `index.html` is a different surface without the contribution CTA
+
+This is fragile because different hosts may not honor or prioritize the root redirect in the same way when `index.html` also exists.
+
+Evidence from the SSG source confirms the intended model:
+
+- [index_renderer.py](/home/sanghop/axis/axis-niddhi-production/pipeline/13-ssg/src/renderers/index_renderer.py:8)
+  - `index.html <- templates/welcome.html`
+  - `archive.html <- templates/index.html`
+
+However, the current generated/static state in the repo shows:
+
+- `pipeline/13-static-site/index.html` is not the same as `pipeline/13-static-site/welcome.html`
+- `welcome.html` includes `CONTRIBUTE`
+- `index.html` does not
+
+That mismatch is the direct source of the parity risk.
+
+## Inspected Files
+
+Production repo:
+
+- `pipeline/13-static-site/_redirects`
+- `pipeline/13-static-site/index.html`
+- `pipeline/13-static-site/welcome.html`
+- `pipeline/13-static-site/contribute.html`
+- `pipeline/13-ssg/templates/index.html`
+- `pipeline/13-ssg/templates/welcome.html`
+- `pipeline/13-ssg/src/renderers/index_renderer.py`
+
+Published payload:
+
+- `pipeline/13-static-site/_redirects`
+- `pipeline/13-static-site/index.html`
+- `pipeline/13-static-site/welcome.html`
+- `pipeline/13-static-site/contribute.html`
+
+## Local File Findings
+
+Production static:
+
+- `_redirects`: `/ /welcome 302`
+- `index.html`: contains `ENTER ARCHIVE` and `ACESSAR ACERVO`, but not `CONTRIBUTE`
+- `welcome.html`: contains:
+  - `ENTER ARCHIVE`
+  - `CONTRIBUTE`
+  - `ACESSAR ACERVO`
+  - `COLABORAR`
+- `contribute.html`: exists and links back to `welcome.html`
+
+Published static:
+
+- Same relevant shape as production for these front files:
+  - `_redirects` present
+  - `index.html` without `CONTRIBUTE`
+  - `welcome.html` with `CONTRIBUTE`
+  - `contribute.html` present
+
+Template/source findings:
+
+- `pipeline/13-ssg/templates/index.html` is the larger archive/library-oriented surface
+- `pipeline/13-ssg/templates/welcome.html` is the discovery landing source
+- Current generated root behavior is therefore too dependent on routing assumptions
+
+## `index.html` vs `welcome.html` Diff Summary
+
+Diff file:
+
+- `/tmp/flagfix_080_index_vs_welcome.diff`
+
+Diff length:
+
+- `139` lines
+
+Important differences:
+
+- `welcome.html` includes the English and Portuguese contribution buttons
+- `index.html` does not
+- `welcome.html` has the approved CTA surface
+- `index.html` has different copy, button set, and structure
+
+This is not a tiny redirect-only discrepancy. These are materially different landing surfaces.
+
+## Option Analysis
+
+### Option A
+
+Force root redirect `/ -> /welcome`.
+
+Pros:
+
+- Small conceptual change
+- Preserves current CTA only in one place
+- Minimal user-facing behavior change if routing works consistently
+
+Cons:
+
+- Relies on host-specific redirect behavior
+- Fragile when `index.html` exists
+- Already behaves differently across Cloudflare and Netlify
+- Makes parity depend on deployment platform rather than on the payload itself
+
+Portability:
+
+- Weakest option across Netlify, Cloudflare, GitHub Pages, and basic local static serving
+
+LABZ impact:
+
+- None directly
+
+Regeneration needed:
+
+- Likely yes, if redirects or root files are changed later
+
+### Option B
+
+Make `index.html` and `welcome.html` both contain the approved CTA surface.
+
+Pros:
+
+- Root surface parity does not depend on redirects
+- Safer across hosts
+- Keeps back-compat for `/welcome`
+- Makes the stable Vitrine experience explicit in both entry files
+
+Cons:
+
+- Duplicates landing logic unless templated carefully
+- Requires deliberate source/template alignment
+
+Portability:
+
+- Strong
+
+LABZ impact:
+
+- None, if LABZ remains excluded from Vitrine scope
+
+Regeneration needed:
+
+- Yes, source-first then static output
+
+### Option C
+
+Make `index.html` the canonical welcome surface and keep `welcome.html` as alias/back-compat.
+
+Pros:
+
+- Cleanest long-term root model
+- Root URL becomes authoritative
+- Easier mental model for deployment targets
+
+Cons:
+
+- Requires clear SSG ownership of landing generation
+- Slightly bigger implementation decision than just duplicating content
+- Need to preserve `/welcome` compatibility intentionally
+
+Portability:
+
+- Strongest long-term option
+
+LABZ impact:
+
+- None, if Vitrine keeps LABZ excluded
+
+Regeneration needed:
+
+- Yes, source-first then static output
+
+### Option D
+
+Leave as-is.
+
+Pros:
+
+- No immediate work
+
+Cons:
+
+- Root parity remains broken
+- Netlify root keeps omitting the approved CTA surface
+- Host behavior remains inconsistent
+- Future deploys remain confusing and harder to validate
+
+Portability:
+
+- Poor
+
+LABZ impact:
+
+- None
+
+Regeneration needed:
+
+- No
+
+## Recommended Option
+
+Recommended direction: `B / C`
+
+Preferred product rule:
+
+- `index.html` should render the same approved Vitrine landing surface as `welcome.html`
+- `welcome.html` may remain as alias/back-compat
+- Do not rely on host-specific root redirect behavior as the only path to the CTA
+
+In practical terms:
+
+- Treat root surface parity as a content/output problem first
+- Treat redirect behavior as optional compatibility, not as the primary guarantee
+
+## Proposed Implementation Sprint
+
+`#FlagFix_081 — Align index and welcome Vitrine landing surface`
+
+Proposed scope for that sprint:
+
+- SSG/source first
+- identify the authoritative landing template path
+- make `index.html` and `welcome.html` intentionally aligned
+- regenerate static output
+- validate root CTA presence locally
+- validate Netlify/Cloudflare parity after approved upload/deploy steps
+- keep LABZ out of Vitrine unless separately approved
+
+## LABZ Exclusion
+
+LABZ is explicitly excluded from this parity fix.
+
+This plan does not propose:
+
+- promoting LABZ to Netlify/Vitrine
+- changing LABZ CSS/HTML/JS
+- using the closed flower preview work in the stable Vitrine
+
+## Explicit Non-Actions
+
+- No deploy
+- No Netlify upload
+- No push
+- No build/pipeline run
+- No DeepL call
+- No translation
+- No CSL changes
+- No metadata CSV changes
+- No `Translation_Control_Center.csv` changes
+- No SP10/SP11 changes
+- No sync/copy
+- No `.gitignore` changes
+- No `/home/sanghop/axis/axis-niddhi-published` changes
+- No production static changes
+- No website file changes


### PR DESCRIPTION
## Summary

Adds #FlagFix_079 and #FlagFix_080.

## #079

Audits Netlify/Cloudflare surface parity and confirms the CONTRIBUTE/ COLABORAR CTA exists in the approved local payload, but is absent from the Netlify public root.

## #080

Plans the root routing and landing-surface parity fix.

## Finding

The issue is not absence of the contribution page. The issue is root surface/routing parity:

- Cloudflare root redirects to /welcome and shows CONTRIBUTE.
- Netlify root serves index.html directly and does not show CONTRIBUTE.
- welcome.html has the approved CTA surface.
- index.html does not.
- _redirects contains / /welcome 302, but relying on host routing is fragile when index.html exists.

## Recommendation

Proceed with #FlagFix_081:

Align index.html and welcome.html so root / shows the approved Vitrine landing surface without depending on host-specific redirects.

LABZ remains excluded.

## Safety

No deploy.
No Netlify upload.
No push except this documentation branch.
No build/pipeline run.
No DeepL call.
No translation.
No sync/copy.
No CSL changes.
No static changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.
No axis-niddhi-published changes.
No production static changes.