### PR TITLE
fix(flagfix): align Vitrine index and welcome landing

### DIFF
--- a/docs/FlagFix/FLAGFIX_081_ALIGN_INDEX_WELCOME_VITRINE_LANDING.md
+++ b/docs/FlagFix/FLAGFIX_081_ALIGN_INDEX_WELCOME_VITRINE_LANDING.md
@@ -1,0 +1,89 @@
+# FlagFix 081 - Align index and welcome Vitrine landing surface
+
+Date: 2026-05-19
+
+## Reason for Patch
+
+FlagFix #079 and #080 confirmed root CTA parity drift:
+
+- Cloudflare root (`/`) redirects to `/welcome`, so public root shows `CONTRIBUTE`.
+- Netlify root (`/`) serves `index.html` directly, so the public root could miss `CONTRIBUTE` when `index.html` diverges.
+- Approved CTA surface existed in `welcome.html`, but not in `index.html`.
+
+To remove host-specific fragility, this patch aligns `index.html` and `welcome.html` to the same approved landing surface.
+
+## Approved Landing Source
+
+Approved CTA landing source used in this patch:
+
+- `pipeline/13-static-site/welcome.html`
+
+The same approved content was propagated to source templates and static root index.
+
+## Files Changed
+
+- `pipeline/13-ssg/templates/index.html`
+- `pipeline/13-ssg/templates/welcome.html`
+- `pipeline/13-static-site/index.html`
+
+No other files were modified.
+
+## CTA Parity Checks
+
+All four target files now contain:
+
+- `ENTER ARCHIVE`
+- `CONTRIBUTE`
+- `ACESSAR ACERVO`
+- `COLABORAR`
+
+## Index/Welcome Diff Results
+
+Static:
+
+- `diff -u pipeline/13-static-site/index.html pipeline/13-static-site/welcome.html`
+- Result: `0` lines
+
+Template:
+
+- `diff -u pipeline/13-ssg/templates/index.html pipeline/13-ssg/templates/welcome.html`
+- Result: `0` lines
+
+Outcome:
+
+- `index.html` now matches `welcome.html` in both static output and SSG source templates.
+
+## Path Scope Result
+
+Path scope validation returned:
+
+- `PATH_SCOPE_OK`
+
+Changed paths stayed within allowed scope.
+
+## LABZ Exclusion Confirmation
+
+- No LABZ CSS/HTML/JS/asset files were touched.
+- No LABZ promotion action was performed.
+- LABZ block remains excluded from Vitrine/Netlify in this sprint.
+
+## No-Deploy / Safety Confirmation
+
+- No deploy
+- No Netlify upload
+- No push
+- No build/pipeline run
+- No CSL changes
+- No metadata CSV changes
+- No `Translation_Control_Center.csv` changes
+- No SP10/SP11 changes
+- No DeepL call
+- No translation
+- No sync/copy to `axis-niddhi-published`
+- No `.gitignore` changes
+
+## Recommendation
+
+Proceed with review of this surgical parity patch.
+
+If approved, package/deploy to Netlify should happen in a separate sprint with standard Vitrine promotion controls.

--- a/pipeline/13-ssg/templates/index.html
+++ b/pipeline/13-ssg/templates/index.html
@@ -1,313 +1,248 @@
-<!-- pipeline/13-ssg/templates/index.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AXIS-NIDDHI — PureDhamma Static Archive</title>
 
-{% extends "base.html" %}
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;1,400&family=Cinzel:wght@400&display=swap');
 
-{% block title %}AXIS-NIDDHI Engine - Dhamma Archive{% endblock %}
+    :root {
+      --gold: #b8975a;
+      --gold-deep: #8a6d3b;
+      --ink: #1c1a17;
+      --ink-soft: #3a3630;
+      --parchment: #faf7f0;
+      --rule: rgba(184,151,90,0.25);
+    }
 
-{% block content %}
+    * { box-sizing: border-box; margin: 0; padding: 0; }
 
-<header class="threshold-header">
+    body {
+      font-family: 'EB Garamond', serif;
+      background: #1a1710;
+      background-image: radial-gradient(circle at center, #2a261d 0%, #1a1710 100%);
+      color: var(--ink);
+      display: flex;
+      justify-content: center;
+      padding: 2rem 1rem;
+      min-height: 100vh;
+      align-items: center;
+    }
 
+    .card {
+      background: var(--parchment);
+      max-width: 820px;
+      width: 100%;
+      border: 1px solid var(--rule);
+      box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+    }
 
-    <div class="visual-anchor" style="margin-bottom: 1.5rem;">
-        <a href="{{ relative_root }}leaf.html" target="_blank" rel="noopener noreferrer" title="Contemplar em Alta Resolução — Let it Flow" style="cursor: zoom-in; display: inline-block;">
-            <img src="{{ relative_root }}assets/BodhiCircuitLeaf.png" alt="Nature's Circuit - Dhamma Wheel Edition" style="
-                width: min(220px, 42vw);
-                filter: drop-shadow(0 0 18px var(--green-axiom));
-                animation: pulse-leaf 5s ease-in-out infinite;
-                opacity: 0.92;
-                transition: transform 0.3s ease;
-            " onmouseover="this.style.transform='scale(1.08)'" onmouseout="this.style.transform='scale(1)'">
-        </a>
-    </div>
-
-    <h1 class="main-title" style="margin-top: 0;">✧ AXIS-NIDDHI ENGINE ✧</h1>
-    <p class="mission-statement" style="opacity: 0.8; font-size: 1.1rem; max-width: 600px; margin: 0.5rem auto 2rem;">
-        A timeless, immutable archive of the nature of Nature's Laws.
-    </p>
-</header>
-
-<section class="archive-clarity-hero" aria-labelledby="archive-clarity-title">
-  <p class="archive-clarity-kicker">Public archive / Acervo público</p>
-  <h2 id="archive-clarity-title">AXIS-NIDDHI Archive</h2>
-  <p class="archive-clarity-copy">
-    Read the original PureDhamma articles, compare Portuguese study translations,
-    and help preserve meaning through careful review.
-  </p>
-  <h3>Acervo AXIS-NIDDHI</h3>
-  <p class="archive-clarity-copy">
-    Leia os artigos originais do PureDhamma, compare as traduções de estudo em
-    português e ajude a preservar o significado com revisão cuidadosa.
-  </p>
-  <div class="archive-clarity-actions">
-    <a href="https://puredhamma.net/" class="archive-clarity-card" target="_blank" rel="noopener noreferrer">Read the original ↗<br><span>Ler original</span></a>
-    <button type="button" class="archive-clarity-card" onclick="setViewMode('comparative'); document.getElementById('view-mode-toggle')?.scrollIntoView({behavior:'smooth', block:'center'});">
-      Compare Portuguese<br><span>Comparar português</span>
-    </button>
-    <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" class="archive-clarity-card" target="_blank" rel="noopener noreferrer">
-      Colaborar na Revisão ↗<br><span>Ajudar com cuidado</span>
-    </a>
-  </div>
-</section>
-
-<!-- BLOCK 3: LIBRARY INTRO (CANONICAL) -->
-<div class="library-intro" style="
-    border: 1px solid var(--green-axiom); 
-    padding: 3rem 2rem; 
-    border-radius: 16px; 
-    text-align: center; 
-    background: rgba(0, 255, 0, 0.01); 
-    margin: 3rem 0;
-    line-height: 1.6;
-    box-shadow: 0 10px 30px rgba(0,0,0,0.05);
-">
-  <div style="text-align: center; margin-top: 1.5rem; margin-bottom: 0.5rem;">
-    <img src="{{ relative_root }}buddha-2.jpg" alt="Buddha Statue" style="
-      width: 85px; 
-      height: auto; 
-      margin-bottom: 0.8rem; 
-      opacity: 0.85;
-      filter: sepia(0.3) contrast(1.1);
-    ">
-    <p style="
-      font-size: 1.25rem;
-      color: var(--gold);
+    .top {
+      background: var(--ink);
       text-align: center;
-      margin-top: 0.5rem;
-      margin-bottom: 2rem;
-      letter-spacing: 0.05em;
-      opacity: 0.85;
+      padding: 2rem;
+    }
+
+    .label {
       font-family: 'Cinzel', serif;
-    ">
-      Buddha’s Teachings per the 
-      <a href="https://puredhamma.net/" target="_blank" style="color: inherit; text-decoration: underline;">PureDhamma.net</a> 
-      website:
-    </p>
-  </div>
+      font-size: 0.6rem;
+      letter-spacing: 0.25em;
+      color: rgba(184,151,90,0.6);
+      text-transform: uppercase;
+      margin-bottom: 0.8rem;
+    }
 
-  <!-- NOVO: Minimum Instructions -->
-  <div class="minimum-instructions" style="
-      max-width: 650px;
-      margin: 2rem auto;
-      text-align: left;
+    .title {
+      font-family: 'Cinzel', serif;
+      color: var(--gold);
+      font-size: 1.8rem;
+    }
+
+    .subtitle {
+      font-style: italic;
+      font-size: 0.9rem;
+      color: rgba(184,151,90,0.6);
+      margin-top: 0.4rem;
+    }
+
+    .section {
+      padding: 2.5rem;
+      border-bottom: 1px solid var(--rule);
+    }
+
+    .lang {
+      font-family: 'Cinzel', serif;
+      font-size: 0.7rem;
+      letter-spacing: 0.2em;
+      color: var(--gold-deep);
+      margin-bottom: 1.2rem;
+      text-transform: uppercase;
+    }
+
+    p {
+      font-size: 1.05rem;
+      line-height: 1.8;
+      margin-bottom: 1rem;
+      color: var(--ink-soft);
+    }
+
+    p.lead {
+      color: var(--ink);
+      font-size: 1.1rem;
+    }
+
+    .invariants {
+      margin-top: 1.5rem;
+      padding: 1rem;
+      border-left: 2px solid var(--gold-deep);
       font-size: 0.95rem;
-      background: rgba(128, 128, 128, 0.05);
-      padding: 1.5rem 2rem;
-      border-radius: 12px;
-      border: 1px solid rgba(128, 128, 128, 0.1);
-  ">
-      <p style="text-align: center; margin-top: 0; margin-bottom: 1.5rem; text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.75rem; color: var(--meta-color);">
-          Minimum Instructions / Instruções Mínimas
-      </p>
+      color: var(--ink-soft);
+    }
 
-      <!-- Instruções em Inglês (en-US) -->
-      <div style="margin-bottom: 1.5rem;">
-          <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem; font-weight: bold; font-size: 1rem;">
-              <span>🇺🇸</span> English
-          </div>
-          <ul style="margin: 0; padding-left: 1.5rem; opacity: 0.9;">
-              <li style="margin-bottom: 0.5rem;"><strong>Appearance Settings:</strong> Theme controls (☀️ 🌙 🌿 🌅 🏔️) are available for reading comfort.</li>
-              <li><strong>Reading Signals:</strong>
-                  <span class="manual-feature-desc">
-                      Terms in <span style="color:var(--term-audio); font-weight:bold;">red</span> have pronunciation recordings — click to hear.
-                      Terms in <span style="color:var(--term-glossary); font-weight:bold;">amber</span> are glossary entries (audio coming soon).
-                  </span>
-              </li>
-          </ul>
-      </div>
-
-      <!-- Instruções em Português (pt-BR) -->
-      <div>
-          <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem; font-weight: bold; font-size: 1rem;">
-              <span>🇧🇷</span> Português
-          </div>
-          <ul style="margin: 0; padding-left: 1.5rem; opacity: 0.9;">
-              <li style="margin-bottom: 0.5rem;"><strong>Configurações de Aparência:</strong> Controles de tema (☀️ 🌙 🌿 🌅 🏔️) para conforto de leitura.</li>
-              <li><strong>Sinais de Leitura:</strong>
-                  <span class="manual-feature-desc">
-                      Termos em <span style="color:var(--term-audio); font-weight:bold;">vermelho</span> têm gravação de pronúncia — clique para ouvir.
-                      Termos em <span style="color:var(--term-glossary); font-weight:bold;">âmbar</span> são entradas do glossário (áudio em breve).
-                  </span>
-              </li>
-          </ul>
-      </div>
-  </div>
-  
-  <!-- Mantido do original: Entry Suggestions -->
-  <div class="guided-entry" style="
-      max-width: 760px;
-      margin: 2.5rem auto 0;
+    .bottom {
       text-align: center;
-      font-size: 0.95rem;
-      color: var(--meta-color);
+      padding: 1.5rem;
+      font-style: italic;
+      font-size: 0.9rem;
+      color: rgba(184,151,90,0.7);
+    }
+
+    .btn-container {
+      margin-top: 2rem;
+      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 0.8rem;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      font-family: 'Cinzel', serif;
+      font-size: 0.72rem;
+      letter-spacing: 0.2em;
+      background: transparent;
+      color: var(--gold);
+      border: 1px solid var(--gold-deep);
+      padding: 0.9rem 1.35rem;
+      text-decoration: none;
+      display: inline-block;
+      transition: 0.3s ease;
+    }
+
+    .btn:hover {
+      background: rgba(184,151,90,0.1);
+    }
+  </style>
+</head>
+
+<body>
+
+<div class="card">
+
+  <div class="top">
+  <img src="buddha-2.jpg" alt="Buddha Statue" style="
+    width: 120px;
+    height: auto;
+    margin-bottom: 1.5rem;
+    opacity: 0.9;
+    filter: sepia(0.2) contrast(1.1);
   ">
-      <p style="margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.75rem;">
-          Entry Suggestions
-      </p>
-      <div class="guided-entry-actions">
-          <a class="entry-action" href="{{ relative_root }}pages/TL.AA.000/index.html" target="_blank" rel="noopener noreferrer">🌱 Start with Three Levels</a>
-          <a class="entry-action" href="{{ relative_root }}pages/BD.AA.000/index.html" target="_blank" rel="noopener noreferrer">🌳 Explore Buddha Dhamma</a>
-          <button type="button" class="entry-action" onclick="setViewMode('comparative'); document.getElementById('view-mode-toggle')?.scrollIntoView({behavior:'smooth', block:'center'});">
-              ◫ View translated articles
-          </button>
-      </div>
-  </div>
+
+  <div class="label">AXIS-NIDDHI</div>
+  <div class="title">PureDhamma Static Archive</div>
+  <div class="subtitle">Read · Compare · Preserve Meaning</div>
 </div>
 
-<!-- [FF-012c] View Mode Toggle — Segmented Control (Apple style) -->
-<div class="view-mode-toggle" id="view-mode-toggle">
-  <div class="toggle-group">
-    <button class="view-btn active" id="btn-reader" data-mode="reader" onclick="setViewMode('reader')">Reader</button>
-    <button class="view-btn" id="btn-comparative" data-mode="comparative" onclick="setViewMode('comparative')">Comparative</button>
-  </div>
+  <div class="section">
+    <div class="lang">English</div>
+
+    <p class="lead">
+      A static doorway into the PureDhamma teaching corpus, preserved for careful reading and translation review.
+    </p>
+
+    <p>
+      AXIS-NIDDHI keeps the archive readable without a live database and helps make reviewed Portuguese access possible.
+    </p>
+
+    <p>
+      The project does not replace PureDhamma.net and does not reinterpret Dhamma. Its job is continuity: source traceability, offline access, and careful review.
+    </p>
+
+    <p>
+      New here? Enter the archive to read, or start with the short orientation guide before reviewing translations.
+    </p>
+
+    <div class="invariants">
+      <strong>Public purpose:</strong><br>
+      Static access · Translation review · Meaning preservation
+    </div>
+
+    <div class="invariants">
+      <strong>Translation note:</strong><br>
+      The Portuguese version is study and review support, not an official, final, or doctrinally certified translation. When in doubt, consult the original English article at PureDhamma.net. Errors in translation, nuance, or terminology may remain and should be reported for review.
+    </div>
+
+<p style="
+  font-size: 1rem;
+  color: rgba(184,151,90,0.7);
+  margin-top: 1.5rem;
+  margin-bottom: 0.2rem;
+  text-align: center;
+  letter-spacing: 0.03em;
+">
+  Buddha’s Teachings per the
+  <a href="https://puredhamma.net/" target="_blank" rel="noopener noreferrer" style="color: inherit; text-decoration: underline;">PureDhamma.net</a>
+  website:
+</p>
+
+<div class="btn-container" style="text-align: center;">
+  <a href="archive.html" class="btn">ENTER ARCHIVE</a>
+  <a href="contribute.html" class="btn">CONTRIBUTE</a>
+  <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/START_HERE.md" class="btn" target="_blank" rel="noopener noreferrer">START HERE</a>
+  <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" class="btn" target="_blank" rel="noopener noreferrer">REVIEW GUIDE</a>
 </div>
 
-<!-- READER MODE (default) -->
-<div class="library-index" id="view-reader">
-
-    <!-- SPRINT D: Section Grid (Overview) -->
-    {%- set EMOJIS = {
-        'AB': '🧠',
-        'BA': '👁️',
-        'BC': '📿',
-        'BD': '🌳',
-        'BM': '🧘',
-        'BS': '📜',
-        'CH': '📊',
-        'CC': '✨',
-        'DD': '📖',
-        'DH': '🏥',
-        'DP': '🔵',
-        'DS': '🔬',
-        'DT': '⏳',
-        'EL': '⚙️',
-        'ER': '🐘',
-        'FT': '📝',
-        'FW': '🧬',
-        'GY': '📚',
-        'HB': '🏛️',
-        'HS': '🏺',
-        'IS': '🪞',
-        'KD': '🔑',
-        'KF': '🗝️',
-        'KS': '⚡',
-        'LD': '🌱',
-        'LP': '🕯️',
-        'MB': '🪷',
-        'MQ': '🌸',
-        'MR': '🌀',
-        'MS': '📌',
-        'NK': '🌟',
-        'NP': '🆕',
-        'OD': '🌌',
-        'PD': 'ℹ️',
-        'PN': '🌠',
-        'PS': '🔗',
-        'PV': '🔮',
-        'QD': '⚛️',
-        'QM': '🌊',
-        'SI': '📖',
-        'SN': '🕊️',
-        'TL': '🌿',
-        'TS': '📋',
-        'VM': '🗺️',
-        'WP': '🌐'
-    } -%}
-    <div class="section-grid">
-        {% for section in nav_tree %}
-        <a href="#section-{{ section.code }}" class="section-card" title="{{ section.title }}" onclick="
-            setTimeout(() => {
-                const h2 = document.querySelector('#section-{{ section.code }} h2');
-                if (h2 && !h2.classList.contains('active')) h2.click();
-            }, 50);
-        ">
-            <span class="section-card-icon">{{ EMOJIS.get(section.code, '🔖') }}</span>
-            <span class="section-card-code">{{ "%02d"|format(loop.index) }} &bull; {{ section.code }}</span>
-            <span class="section-card-title">{{ section.title }}</span>
-        </a>
-        {% endfor %}
-    </div>
-    <div id="inline-section-panel" class="inline-section-panel" hidden></div>
-
-    <div class="section-list-toggle-wrap">
-        <button type="button" id="section-list-toggle" class="section-list-toggle" aria-expanded="false">
-            View all sections / Ver todas as seções
-        </button>
-    </div>
-
-    <div id="all-sections-list" class="all-sections-list">
-    <!-- Lista Colapsável (Accordion) -->
-    {% for section in nav_tree %}
-    <section class="library-section" id="section-{{ section.code }}">
-        <h2 class="accordion-header" style="cursor: pointer; display: flex; align-items: center; gap: 0.8rem;">
-            <span class="toggle-icon" style="color: var(--green-axiom); font-size: 0.8rem; transition: transform 0.3s;">▶</span>
-            <span class="section-code">{{ section.code }}</span>
-            <span class="section-title">{{ section.title }}</span>
-        </h2>
-        <ul class="post-list accordion-content" style="max-height: 0; overflow: hidden; transition: max-height 0.4s ease-in-out; margin-left: 1.6rem; padding-left: 0; list-style: none;">
-            {% for post in section.posts %}
-            <li>
-                <span class="findex">{{ post.findex }}</span>
-                <a href="{{ relative_root }}pages/{{ post.pdpn }}/index.html">
-                    {{ post.titles.en }}
-                </a>
-            </li>
-            {% endfor %}
-        </ul>
-    </section>
-    {% endfor %}
-    </div>
-</div>
-
-<!-- COMPARATIVE MODE [FF-012] — hidden by default, shown via JS toggle -->
-<div class="dual-index" id="view-comparative" hidden>
-
-  <!-- Header row -->
-  <div class="index-row index-header">
-    <div class="index-cell pdpn">PDPN</div>
-    <div class="index-cell">English Title</div>
-    <div class="index-cell">Portuguese Title</div>
   </div>
 
-  {% for section in nav_tree %}
-  <!-- Section separator row -->
-  <div class="index-row index-section-row">
-    <div class="index-cell index-section-label" style="grid-column: 1 / -1;">
-      {{ section.code }} — {{ section.title }}
-    </div>
-  </div>
+  <section class="section">
+    <div class="lang">Português</div>
 
-  {% for post in section.posts %}
-  {%- if post.has_pt_content %}
-    {%- set pt_class = "pt-complete" %}
-  {%- elif post.has_pt_title %}
-    {%- set pt_class = "pt-title-only" %}
-  {%- else %}
-    {%- set pt_class = "pt-missing" %}
-  {%- endif %}
-  <div class="index-row" data-pdpn="{{ post.pdpn }}">
-    <div class="index-cell pdpn">
-      <a href="{{ relative_root }}pages/{{ post.pdpn }}/index.html">{{ post.pdpn }}</a>
+    <p class="lead">
+      Esta vitrine preserva e apresenta o conteúdo do PureDhamma.net em formato
+      estático, simples e acessível.
+    </p>
+
+    <p>
+      A intenção é abrir uma porta para quem ainda não lê inglês com fluência:
+      estudar, comparar, revisar e se aproximar do Dhamma com mais clareza,
+      sem substituir a fonte original.
+    </p>
+
+    <div class="invariants">
+      <strong>Aviso sobre a tradução:</strong><br>
+      A versão em português é oferecida como apoio de estudo e revisão.
+      Ela não é tradução oficial, final ou certificada.
+      Como o Dhamma é profundo e a linguagem pode alterar o sentido,
+      erros de tradução, nuance ou terminologia ainda podem existir.
+      Em caso de dúvida, consulte sempre o texto original em inglês no
+      PureDhamma.net.
     </div>
-    <div class="index-cell en">
-      {{ post.titles.get('en', post.pdpn) }}
+
+    <div class="btn-container">
+      <a class="btn primary" href="archive.html">ACESSAR ACERVO</a>
+      <a class="btn" href="contribute.html">COLABORAR</a>
+      <a class="btn" href="https://github.com/matikamata/axis-niddhi/blob/main/docs/START_HERE.md" target="_blank" rel="noopener noreferrer">COMECE AQUI</a>
+      <a class="btn" href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" target="_blank" rel="noopener noreferrer">GUIA DE REVISÃO</a>
     </div>
-    <div class="index-cell pt {{ pt_class }}">
-      {%- if post.titles.get('pt') %}
-        {{ post.titles.get('pt') }}
-        {%- if post.has_pt_content %}
-          <span class="pt-badge">✓</span>
-        {%- else %}
-          <span class="pt-badge pt-badge-title">T</span>
-        {%- endif %}
-      {%- else %}
-        <em>Awaiting translation / Aguardando tradução</em>
-      {%- endif %}
-    </div>
+  </section>
+
+  <div class="bottom">
+    Preserved with respect · Reviewed with care · Preservado com respeito
   </div>
-  {% endfor %}
-  {% endfor %}
 
 </div>
 
-{% endblock %}
+</body>
+</html>

--- a/pipeline/13-ssg/templates/welcome.html
+++ b/pipeline/13-ssg/templates/welcome.html
@@ -143,13 +143,13 @@
 
   <div class="top">
   <img src="buddha-2.jpg" alt="Buddha Statue" style="
-    width: 120px; 
-    height: auto; 
-    margin-bottom: 1.5rem; 
+    width: 120px;
+    height: auto;
+    margin-bottom: 1.5rem;
     opacity: 0.9;
     filter: sepia(0.2) contrast(1.1);
   ">
-  
+
   <div class="label">AXIS-NIDDHI</div>
   <div class="title">PureDhamma Static Archive</div>
   <div class="subtitle">Read · Compare · Preserve Meaning</div>
@@ -161,8 +161,8 @@
     <p class="lead">
       A static doorway into the PureDhamma teaching corpus, preserved for careful reading and translation review.
     </p>
-    
-    <p>    
+
+    <p>
       AXIS-NIDDHI keeps the archive readable without a live database and helps make reviewed Portuguese access possible.
     </p>
 
@@ -184,7 +184,6 @@
       The Portuguese version is study and review support, not an official, final, or doctrinally certified translation. When in doubt, consult the original English article at PureDhamma.net. Errors in translation, nuance, or terminology may remain and should be reported for review.
     </div>
 
-<!-- Attribution line (per Prof. Lal) -->
 <p style="
   font-size: 1rem;
   color: rgba(184,151,90,0.7);
@@ -193,69 +192,51 @@
   text-align: center;
   letter-spacing: 0.03em;
 ">
-  Buddha’s Teachings per the 
-  <a href="https://puredhamma.net/" target="_blank" style="color: inherit; text-decoration: underline;">PureDhamma.net</a> 
+  Buddha’s Teachings per the
+  <a href="https://puredhamma.net/" target="_blank" rel="noopener noreferrer" style="color: inherit; text-decoration: underline;">PureDhamma.net</a>
   website:
 </p>
 
 <div class="btn-container" style="text-align: center;">
   <a href="archive.html" class="btn">ENTER ARCHIVE</a>
-  <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/START_HERE.md" class="btn">START HERE</a>
-  <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" class="btn">REVIEW GUIDE</a>
+  <a href="contribute.html" class="btn">CONTRIBUTE</a>
+  <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/START_HERE.md" class="btn" target="_blank" rel="noopener noreferrer">START HERE</a>
+  <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" class="btn" target="_blank" rel="noopener noreferrer">REVIEW GUIDE</a>
 </div>
 
   </div>
 
-  <div class="section">
+  <section class="section">
     <div class="lang">Português</div>
 
     <p class="lead">
-      Uma porta de entrada estática para o corpus PureDhamma, preservado para leitura cuidadosa e revisão de tradução.
-    </p>
-
-    <p>    
-      O AXIS-NIDDHI mantém o acervo legível sem banco de dados ativo e ajuda a tornar possível o acesso em português revisado.
+      Esta vitrine preserva e apresenta o conteúdo do PureDhamma.net em formato
+      estático, simples e acessível.
     </p>
 
     <p>
-      O projeto não substitui o PureDhamma.net e não reinterpreta o Dhamma. Sua função é continuidade: rastreabilidade da fonte, acesso offline e revisão cuidadosa.
+      A intenção é abrir uma porta para quem ainda não lê inglês com fluência:
+      estudar, comparar, revisar e se aproximar do Dhamma com mais clareza,
+      sem substituir a fonte original.
     </p>
-
-    <p>
-      Chegando agora? Acesse o acervo para ler, ou comece pelo guia curto antes de revisar traduções.
-    </p>
-
-    <div class="invariants">
-      <strong>Propósito público:</strong><br>
-      Acesso estático · Revisão de tradução · Preservação do significado
-    </div>
 
     <div class="invariants">
       <strong>Aviso sobre a tradução:</strong><br>
-      Esta versão em português é apoio de estudo para leitores que não leem inglês com fluência. Ela não é tradução oficial, final ou doutrinariamente certificada. Em caso de dúvida, consulte o artigo original em inglês em PureDhamma.net. Que quaisquer erros sejam encontrados e corrigidos rapidamente, sem causar confusão no Caminho.
+      A versão em português é oferecida como apoio de estudo e revisão.
+      Ela não é tradução oficial, final ou certificada.
+      Como o Dhamma é profundo e a linguagem pode alterar o sentido,
+      erros de tradução, nuance ou terminologia ainda podem existir.
+      Em caso de dúvida, consulte sempre o texto original em inglês no
+      PureDhamma.net.
     </div>
 
-    <!-- Attribution line (per Prof. Lal) -->
-<p style="
-  font-size: 1rem;
-  color: rgba(184,151,90,0.7);
-  margin-top: 1.5rem;
-  margin-bottom: 0.2rem;
-  text-align: center;
-  letter-spacing: 0.03em;
-">
-  Ensinamentos do Buddha de acordo com o website
-  <a href="https://puredhamma.net/" target="_blank" style="color: inherit; text-decoration: underline;">PureDhamma.net</a> 
-  :
-</p>
-
-    <div class="btn-container" style="text-align: center;">
-      <a href="archive.html" class="btn">ACESSAR ACERVO</a>
-      <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/START_HERE.md" class="btn">COMECE AQUI</a>
-      <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" class="btn">GUIA DE REVISAO</a>
+    <div class="btn-container">
+      <a class="btn primary" href="archive.html">ACESSAR ACERVO</a>
+      <a class="btn" href="contribute.html">COLABORAR</a>
+      <a class="btn" href="https://github.com/matikamata/axis-niddhi/blob/main/docs/START_HERE.md" target="_blank" rel="noopener noreferrer">COMECE AQUI</a>
+      <a class="btn" href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" target="_blank" rel="noopener noreferrer">GUIA DE REVISÃO</a>
     </div>
-
-  </div>
+  </section>
 
   <div class="bottom">
     Preserved with respect · Reviewed with care · Preservado com respeito

--- a/pipeline/13-static-site/index.html
+++ b/pipeline/13-static-site/index.html
@@ -143,13 +143,13 @@
 
   <div class="top">
   <img src="buddha-2.jpg" alt="Buddha Statue" style="
-    width: 120px; 
-    height: auto; 
-    margin-bottom: 1.5rem; 
+    width: 120px;
+    height: auto;
+    margin-bottom: 1.5rem;
     opacity: 0.9;
     filter: sepia(0.2) contrast(1.1);
   ">
-  
+
   <div class="label">AXIS-NIDDHI</div>
   <div class="title">PureDhamma Static Archive</div>
   <div class="subtitle">Read · Compare · Preserve Meaning</div>
@@ -161,8 +161,8 @@
     <p class="lead">
       A static doorway into the PureDhamma teaching corpus, preserved for careful reading and translation review.
     </p>
-    
-    <p>    
+
+    <p>
       AXIS-NIDDHI keeps the archive readable without a live database and helps make reviewed Portuguese access possible.
     </p>
 
@@ -184,7 +184,6 @@
       The Portuguese version is study and review support, not an official, final, or doctrinally certified translation. When in doubt, consult the original English article at PureDhamma.net. Errors in translation, nuance, or terminology may remain and should be reported for review.
     </div>
 
-<!-- Attribution line (per Prof. Lal) -->
 <p style="
   font-size: 1rem;
   color: rgba(184,151,90,0.7);
@@ -193,69 +192,51 @@
   text-align: center;
   letter-spacing: 0.03em;
 ">
-  Buddha’s Teachings per the 
-  <a href="https://puredhamma.net/" target="_blank" style="color: inherit; text-decoration: underline;">PureDhamma.net</a> 
+  Buddha’s Teachings per the
+  <a href="https://puredhamma.net/" target="_blank" rel="noopener noreferrer" style="color: inherit; text-decoration: underline;">PureDhamma.net</a>
   website:
 </p>
 
 <div class="btn-container" style="text-align: center;">
   <a href="archive.html" class="btn">ENTER ARCHIVE</a>
-  <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/START_HERE.md" class="btn">START HERE</a>
-  <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" class="btn">REVIEW GUIDE</a>
+  <a href="contribute.html" class="btn">CONTRIBUTE</a>
+  <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/START_HERE.md" class="btn" target="_blank" rel="noopener noreferrer">START HERE</a>
+  <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" class="btn" target="_blank" rel="noopener noreferrer">REVIEW GUIDE</a>
 </div>
 
   </div>
 
-  <div class="section">
+  <section class="section">
     <div class="lang">Português</div>
 
     <p class="lead">
-      Uma porta de entrada estática para o corpus PureDhamma, preservado para leitura cuidadosa e revisão de tradução.
-    </p>
-
-    <p>    
-      O AXIS-NIDDHI mantém o acervo legível sem banco de dados ativo e ajuda a tornar possível o acesso em português revisado.
+      Esta vitrine preserva e apresenta o conteúdo do PureDhamma.net em formato
+      estático, simples e acessível.
     </p>
 
     <p>
-      O projeto não substitui o PureDhamma.net e não reinterpreta o Dhamma. Sua função é continuidade: rastreabilidade da fonte, acesso offline e revisão cuidadosa.
+      A intenção é abrir uma porta para quem ainda não lê inglês com fluência:
+      estudar, comparar, revisar e se aproximar do Dhamma com mais clareza,
+      sem substituir a fonte original.
     </p>
-
-    <p>
-      Chegando agora? Acesse o acervo para ler, ou comece pelo guia curto antes de revisar traduções.
-    </p>
-
-    <div class="invariants">
-      <strong>Propósito público:</strong><br>
-      Acesso estático · Revisão de tradução · Preservação do significado
-    </div>
 
     <div class="invariants">
       <strong>Aviso sobre a tradução:</strong><br>
-      Esta versão em português é apoio de estudo para leitores que não leem inglês com fluência. Ela não é tradução oficial, final ou doutrinariamente certificada. Em caso de dúvida, consulte o artigo original em inglês em PureDhamma.net. Que quaisquer erros sejam encontrados e corrigidos rapidamente, sem causar confusão no Caminho.
+      A versão em português é oferecida como apoio de estudo e revisão.
+      Ela não é tradução oficial, final ou certificada.
+      Como o Dhamma é profundo e a linguagem pode alterar o sentido,
+      erros de tradução, nuance ou terminologia ainda podem existir.
+      Em caso de dúvida, consulte sempre o texto original em inglês no
+      PureDhamma.net.
     </div>
 
-    <!-- Attribution line (per Prof. Lal) -->
-<p style="
-  font-size: 1rem;
-  color: rgba(184,151,90,0.7);
-  margin-top: 1.5rem;
-  margin-bottom: 0.2rem;
-  text-align: center;
-  letter-spacing: 0.03em;
-">
-  Ensinamentos do Buddha de acordo com o website
-  <a href="https://puredhamma.net/" target="_blank" style="color: inherit; text-decoration: underline;">PureDhamma.net</a> 
-  :
-</p>
-
-    <div class="btn-container" style="text-align: center;">
-      <a href="archive.html" class="btn">ACESSAR ACERVO</a>
-      <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/START_HERE.md" class="btn">COMECE AQUI</a>
-      <a href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" class="btn">GUIA DE REVISAO</a>
+    <div class="btn-container">
+      <a class="btn primary" href="archive.html">ACESSAR ACERVO</a>
+      <a class="btn" href="contribute.html">COLABORAR</a>
+      <a class="btn" href="https://github.com/matikamata/axis-niddhi/blob/main/docs/START_HERE.md" target="_blank" rel="noopener noreferrer">COMECE AQUI</a>
+      <a class="btn" href="https://github.com/matikamata/axis-niddhi/blob/main/docs/TRANSLATION_REVIEW_GUIDE.md" target="_blank" rel="noopener noreferrer">GUIA DE REVISÃO</a>
     </div>
-
-  </div>
+  </section>
 
   <div class="bottom">
     Preserved with respect · Reviewed with care · Preservado com respeito


### PR DESCRIPTION
## Summary

Adds #FlagFix_081: aligns the Vitrine root landing surface so index.html and welcome.html show the same approved CTA surface.

## Changes

- pipeline/13-ssg/templates/index.html
- pipeline/13-ssg/templates/welcome.html
- pipeline/13-static-site/index.html
- docs/FlagFix/FLAGFIX_081_ALIGN_INDEX_WELCOME_VITRINE_LANDING.md

## Result

- static index.html vs welcome.html: 0 diff lines
- template index.html vs welcome.html: 0 diff lines
- index.html now includes:
  - ENTER ARCHIVE
  - CONTRIBUTE
  - ACESSAR ACERVO
  - COLABORAR

## Safety

No deploy.
No Netlify upload.
No build/pipeline run.
No DeepL call.
No translation.
No sync/copy to axis-niddhi-published.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.
No LABZ promotion.
No LABZ/Bodhi/flower files touched.

## Next

After merge, run a new checkpoint and then decide whether to package/promote this root parity fix to the Netlify Vitrine in a later sprint.