### PR TITLE
docs(flagfix): record published root CTA parity commit

### DIFF
--- a/docs/FlagFix/FLAGFIX_083_COMMIT_PUBLISHED_ROOT_CTA_PARITY.md
+++ b/docs/FlagFix/FLAGFIX_083_COMMIT_PUBLISHED_ROOT_CTA_PARITY.md
@@ -1,0 +1,91 @@
+# FlagFix 083 - Commit published root CTA parity payload
+
+Date: 2026-05-19
+
+## Summary
+
+This sprint committed the already prepared published payload update from #FlagFix_082 in:
+
+- `/home/sanghop/axis/axis-niddhi-published`
+
+Scope was intentionally minimal:
+
+- only `pipeline/13-static-site/index.html`
+
+## Published Commit
+
+- Commit hash: `5da4e59`
+- Commit message: `fix(vitrine): align root landing CTA`
+- Changed path:
+  - `pipeline/13-static-site/index.html`
+
+## Path Scope Check
+
+Scope validation command confirmed:
+
+- `PATH_SCOPE_OK`
+
+No extra changed paths were present before commit.
+
+## CTA Confirmation
+
+Published `index.html` now contains:
+
+- `ENTER ARCHIVE`
+- `CONTRIBUTE`
+- `ACESSAR ACERVO`
+- `COLABORAR`
+
+## Production/Published Index Parity
+
+Parity check:
+
+- `/home/sanghop/axis/axis-niddhi-production/pipeline/13-static-site/index.html`
+- `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site/index.html`
+
+Result:
+
+- `/tmp/flagfix_083_index_parity.diff`
+- diff lines: `0`
+
+## LABZ Exclusion
+
+Checked published changed paths for:
+
+- `labz`
+- `flower` / `flores`
+- `bodhi`
+
+Result:
+
+- no matches
+- LABZ/Bodhi/flower files untouched in this sprint
+
+## Published Repo Status After Commit
+
+Post-commit status:
+
+- `main...origin/main [ahead 2]`
+- working tree clean
+- no push performed
+
+## Safety Confirmations
+
+- No push
+- No deploy
+- No Netlify upload
+- No build/pipeline run
+- No DeepL call
+- No translation
+- No CSL changes
+- No metadata CSV changes
+- No `Translation_Control_Center.csv` changes
+- No SP10/SP11 changes
+- No sync/copy
+- No `.gitignore` changes
+
+## Next Recommendation
+
+`#FlagFix_084 — Netlify upload/smoke check or deployment hold`
+
+Decide whether to upload this published payload to Netlify now, or keep a deployment hold pending additional release checks.


### PR DESCRIPTION
## Summary

Adds #FlagFix_083: records the local published repo commit that aligns the Netlify/Vitrine root landing CTA.

## Published commit

- commit: 5da4e59
- changed path: pipeline/13-static-site/index.html

## Validation

- production index vs published index diff: 0 lines
- CTA present in published index.html:
  - ENTER ARCHIVE
  - CONTRIBUTE
  - ACESSAR ACERVO
  - COLABORAR
- path scope: PATH_SCOPE_OK
- LABZ/Bodhi/flower files untouched
- published repo status: main...origin/main [ahead 2], working tree clean

## Safety

No deploy.
No Netlify upload.
No push from published repo.
No build/pipeline run.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.
No additional sync/copy.