### PR TITLE
fix(flagfix): neutralize contribute staging copy

### DIFF
--- a/docs/FlagFix/FLAGFIX_085_FIX_CLOUDFLARE_STAGING_COPY.md
+++ b/docs/FlagFix/FLAGFIX_085_FIX_CLOUDFLARE_STAGING_COPY.md
@@ -1,0 +1,76 @@
+# FlagFix 085 - Fix Cloudflare staging copy on public contribute surface
+
+Date: 2026-05-19
+
+## Reason for Fix
+
+After root CTA parity was corrected, the public `contribute.html` still displayed host-specific wording:
+
+- `AXIS-NIDDHI Cloudflare Staging`
+
+That wording is not appropriate for stable Vitrine copy and should be host-neutral.
+
+## Copy Change
+
+Old wording:
+
+- `AXIS-NIDDHI Cloudflare Staging`
+
+New wording:
+
+- `AXIS-NIDDHI Collaboration Surface`
+
+Additional neutralization applied in body text:
+
+- English section:
+  - from `This Cloudflare site ... staging surface ...`
+  - to `This site ... collaboration surface ...`
+- Portuguese section:
+  - from `Este site no Cloudflare ...`
+  - to `Este site é ...`
+
+## Files Changed
+
+- `pipeline/13-static-site/contribute.html`
+
+No template source file for contribute was found under:
+
+- `pipeline/13-ssg/templates/contribute.html` (missing)
+- `pipeline/13-ssg/static/contribute.html` (missing)
+
+## Remaining `Cloudflare Staging` Hits
+
+Checked:
+
+- `pipeline/13-static-site/contribute.html`
+- `pipeline/13-ssg/**`
+
+Result:
+
+- no remaining `Cloudflare Staging` / `cloudflare staging` hits in these contribute/source locations.
+
+Neutral label presence check:
+
+- `AXIS-NIDDHI Collaboration Surface` found in `pipeline/13-static-site/contribute.html`.
+
+## LABZ Exclusion Confirmation
+
+- No LABZ files changed.
+- No Bodhi/flower files changed.
+- No LABZ promotion action performed.
+
+## Scope / Safety Confirmation
+
+- Changed path scope is minimal:
+  - only `pipeline/13-static-site/contribute.html`
+- No deploy
+- No Netlify upload
+- No build/pipeline run
+- No DeepL call
+- No translation workflow change
+- No CSL/metadata/TCC/SP10/SP11 changes
+- No sync/copy to `axis-niddhi-published`
+
+## Recommendation
+
+After merge, promote this small copy patch to published/Netlify in a separate sprint and run a focused public smoke check for `contribute.html`.

--- a/pipeline/13-static-site/contribute.html
+++ b/pipeline/13-static-site/contribute.html
@@ -444,7 +444,7 @@
         <a class="btn" href="archive.html">Open Archive</a>
         <a class="btn" href="https://github.com/matikamata/axis-niddhi" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
       </nav>
-      <p class="kicker">AXIS-NIDDHI Cloudflare Staging</p>
+      <p class="kicker">AXIS-NIDDHI Collaboration Surface</p>
       <h1>Contribute / Colaborar</h1>
       <p class="subtitle">For developers, reviewers, translators, and careful readers</p>
       <p class="subtitle">Para desenvolvedores, revisores, tradutores e leitores cuidadosos</p>
@@ -481,7 +481,7 @@
         <section>
           <h2>1. Welcome to the development side</h2>
           <p>
-            This Cloudflare site is not only a reading doorway. It is the developer and reviewer side of AXIS-NIDDHI: a staging surface for preservation, translation review, UI/UX testing, and multilingual engine development.
+            This site is not only a reading doorway. It is the developer and reviewer side of AXIS-NIDDHI: a collaboration surface for preservation, translation review, UI/UX testing, and multilingual engine development.
           </p>
           <p>
             Come and see for yourself. Nothing here asks for blind trust; the work is meant to be inspected, compared, and improved carefully.
@@ -565,7 +565,7 @@
         <section>
     <h2>1. Porta de entrada para desenvolvedores e revisores</h2>
     <p>
-      Este site no Cloudflare é uma porta de entrada para quem deseja colaborar com
+      Este site é uma porta de entrada para quem deseja colaborar com
       atenção e cuidado.
       Aqui, o AXIS-NIDDHI ainda está em oficina: preservando o
       conteúdo, revisando traduções, ajustando a experiência de leitura e preparando


### PR DESCRIPTION
## Summary

Adds #FlagFix_085: removes host-specific Cloudflare staging wording from the public contribute surface.

## Change

Old copy:

```text
AXIS-NIDDHI Cloudflare Staging
```

New copy:

```text
AXIS-NIDDHI Collaboration Surface
```

Also neutralizes body copy:

- EN: Cloudflare/staging wording -> site/collaboration surface wording
- PT: Cloudflare-specific wording -> neutral site wording

## Files changed

- pipeline/13-static-site/contribute.html
- docs/FlagFix/FLAGFIX_085_FIX_CLOUDFLARE_STAGING_COPY.md

## Validation

- Cloudflare Staging residual hits: none in contribute.html / SSG checked scope
- LABZ/Bodhi/flower files untouched
- git diff --check passed

## Safety

No deploy.
No Netlify upload.
No build/pipeline run.
No sync to axis-niddhi-published.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.
No LABZ promotion.

## Next

Promote this tiny contribute copy patch to the local published payload, then upload/smoke check in a later sprint.