### PR TITLE
docs(flagfix): promote neutral contribute copy to published payload

### DIFF
--- a/docs/FlagFix/FLAGFIX_086_PROMOTE_NEUTRAL_CONTRIBUTE_COPY_TO_PUBLISHED.md
+++ b/docs/FlagFix/FLAGFIX_086_PROMOTE_NEUTRAL_CONTRIBUTE_COPY_TO_PUBLISHED.md
@@ -1,0 +1,81 @@
+# FlagFix 086 - Promote neutral contribute copy to published payload
+
+Date: 2026-05-19
+
+## Summary
+
+This sprint promoted the neutralized contribute copy from production static to published payload by copying only one file:
+
+- from `/home/sanghop/axis/axis-niddhi-production/pipeline/13-static-site/contribute.html`
+- to `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site/contribute.html`
+
+## Copy Change
+
+Old copy:
+
+- `AXIS-NIDDHI Cloudflare Staging`
+
+New copy:
+
+- `AXIS-NIDDHI Collaboration Surface`
+
+## Verification Results
+
+Production source check:
+
+- no `AXIS-NIDDHI Cloudflare Staging`
+- `AXIS-NIDDHI Collaboration Surface` present
+
+Published target before copy:
+
+- had `AXIS-NIDDHI Cloudflare Staging`
+
+Published target after copy:
+
+- no `AXIS-NIDDHI Cloudflare Staging`
+- `AXIS-NIDDHI Collaboration Surface` present
+
+Production/published parity check:
+
+- `/tmp/flagfix_086_contribute_parity.diff`
+- line count: `0`
+
+## Published Path Scope Result
+
+Path-scope guard result:
+
+- `PATH_SCOPE_OK`
+
+Published `git` status detail:
+
+- `main...origin/main [ahead 2]`
+- no tracked diff output after copy
+
+Important note:
+
+- `pipeline/13-static-site/contribute.html` is not currently tracked in `axis-niddhi-published` (`git ls-files` lists `index.html`, but not `contribute.html`).
+- The file content was updated on disk and now matches production, but this specific file does not appear as a tracked pending change in published.
+
+## LABZ Exclusion
+
+- No LABZ file changes
+- No Bodhi/flower file changes
+- No LABZ promotion
+
+## Safety / Non-Actions
+
+- No deploy
+- No Netlify upload
+- No build/pipeline run
+- No DeepL call
+- No translation
+- No CSL changes
+- No metadata CSV changes
+- No `Translation_Control_Center.csv` changes
+- No SP10/SP11 changes
+- No broad static sync/copy
+- No `.gitignore` changes
+
+## Recommendation
+
+Proceed with a dedicated published-tracking decision for `contribute.html` and then run Netlify upload/smoke check in a follow-up sprint.


### PR DESCRIPTION
## Summary

Adds #FlagFix_086: records the surgical promotion of neutral contribute copy to the local published payload.

## Change

Copied only:

- from: /home/sanghop/axis/axis-niddhi-production/pipeline/13-static-site/contribute.html
- to: /home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site/contribute.html

## Result

- production vs published contribute.html diff: 0 lines
- residual Cloudflare Staging copy: none
- new copy confirmed: AXIS-NIDDHI Collaboration Surface
- LABZ/Bodhi/flower files untouched

## Important observation

pipeline/13-static-site/contribute.html is not tracked in the axis-niddhi-published repo. The promotion exists on disk and is valid for manual Netlify upload, but it does not create a normal tracked Git diff in the published repo.

## Safety

No deploy.
No Netlify upload.
No build/pipeline run.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No broad static sync.
No .gitignore changes.
No LABZ promotion.