### PR TITLE
docs(flagfix): record Netlify root and contribute smoke check

### DIFF
--- a/docs/FlagFix/FLAGFIX_087_NETLIFY_UPLOAD_AND_SMOKE_CHECK_ROOT_CONTRIBUTE.md
+++ b/docs/FlagFix/FLAGFIX_087_NETLIFY_UPLOAD_AND_SMOKE_CHECK_ROOT_CONTRIBUTE.md
@@ -1,0 +1,88 @@
+# FlagFix 087 - Netlify upload and smoke check for root/contribute CTA copy
+
+Date: 2026-05-19
+
+## Upload Status
+
+Manual upload status:
+
+- `COMPLETED` (manual upload confirmed by human)
+
+Deployment was manually executed by the human using:
+
+- `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site`
+
+## Upload Source Folder
+
+Use exactly:
+
+- `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site`
+
+Validated local source:
+
+- exists: `yes`
+- file count: `3082`
+- size: `807M`
+
+## Local Pre-Upload Validation
+
+Published local root `index.html` contains:
+
+- `ENTER ARCHIVE`
+- `CONTRIBUTE`
+- `ACESSAR ACERVO`
+- `COLABORAR`
+
+Published local `contribute.html` contains:
+
+- `AXIS-NIDDHI Collaboration Surface`
+
+Published local `contribute.html` no longer contains:
+
+- `AXIS-NIDDHI Cloudflare Staging`
+
+Published repo status:
+
+- `main...origin/main [ahead 2]`
+- working tree clean
+
+## Public Smoke Check Results
+
+Manual browser/web verification after upload:
+
+- `https://niddhi.netlify.app/`: `PASS`
+  - `ENTER ARCHIVE` present
+  - `CONTRIBUTE` present
+  - `ACESSAR ACERVO` present
+  - `COLABORAR` present
+
+- `https://niddhi.netlify.app/welcome`: `PASS`
+  - same CTA surface confirmed
+
+- `https://niddhi.netlify.app/contribute`: `PASS`
+  - `AXIS-NIDDHI Collaboration Surface` present
+  - `AXIS-NIDDHI Cloudflare Staging` absent
+  - neutral body copy visible
+
+## LABZ Exclusion Confirmation
+
+- No LABZ promotion performed.
+- No LABZ/Bodhi/flower file modifications in this sprint.
+
+## Explicit Non-Actions
+
+- No build/pipeline run
+- No DeepL call
+- No translation
+- No CSL changes
+- No metadata CSV changes
+- No TCC/SP10/SP11 changes
+- No sync/copy actions
+- No `.gitignore` changes
+- No push
+
+## Next Step
+
+Upload and smoke checks are now complete for root/contribute CTA copy parity.
+
+Proceed with normal release hygiene in follow-up checkpoints as needed.


### PR DESCRIPTION
## Summary

Adds #FlagFix_087: records the completed manual Netlify upload and public smoke check for the root CTA and neutral contribute copy.

## Upload

Manual Netlify upload completed by human.

Source used:

```text
/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site
```

## Public smoke check

- https://niddhi.netlify.app/ — PASS
  - ENTER ARCHIVE
  - CONTRIBUTE
  - ACESSAR ACERVO
  - COLABORAR

- https://niddhi.netlify.app/welcome — PASS
  - same CTA surface

- https://niddhi.netlify.app/contribute — PASS
  - AXIS-NIDDHI Collaboration Surface present
  - AXIS-NIDDHI Cloudflare Staging absent

## LABZ

LABZ was not promoted in this sprint.

## Safety

No build/pipeline run.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No sync/copy by agent.
No .gitignore changes.
No push from published repo.