### PR TITLE
style(flagfix): polish LABZ ambient layer for Cloudflare preview

### DIFF
--- a/docs/FlagFix/FLAGFIX_092_LABZ_MINIMAL_VISUAL_POLISH_CLOUDFLARE_ONLY.md
+++ b/docs/FlagFix/FLAGFIX_092_LABZ_MINIMAL_VISUAL_POLISH_CLOUDFLARE_ONLY.md
@@ -1,0 +1,64 @@
+# #FlagFix_092 — LABZ Minimal Visual Polish Patch on Cloudflare Only
+
+## Purpose
+Apply a minimal, reversible LABZ visual polish patch for Cloudflare-facing production static/source only, without any Netlify/Vitrine promotion.
+
+## Files changed
+- `pipeline/13-ssg/static/css/style.css`
+- `pipeline/13-static-site/css/style.css`
+
+Patch type: `CSS-only`
+
+## Design issue addressed
+From #090/#091 hold:
+- ambient visuals were too prominent for stable-facing hierarchy
+- motion needed to be calmer
+- print/reduced-motion guards needed explicit reinforcement
+
+## Exact polish decisions
+1. Reduced side-art prominence:
+   - side image opacity: `0.44 -> 0.28`
+   - motif opacity: `0.16 -> 0.09`
+   - motif border/halo softened
+2. Reduced visual footprint:
+   - side panel width: `156px -> 128px`
+   - side placement shifted farther from content edges
+   - vertical bounds tightened (`top/bottom`)
+3. Calmed animation:
+   - base duration: `12s -> 18s`
+   - stagger durations: `15/18s -> 22/26s`
+   - float amplitude: `12px -> 6px`
+4. Added explicit reduced-motion fallback:
+   - `@media (prefers-reduced-motion: reduce)` disables ambient motif animation
+5. Added explicit print isolation:
+   - `@media print { .labz-ambient-layer { display: none !important; } }`
+
+## Path scope result
+`PATH_SCOPE_OK`
+
+Changed paths are restricted to LABZ CSS counterparts plus this report.
+
+## Print/reduced-motion/mobile considerations
+- Print: LABZ ambient layer now explicitly forced off in print.
+- Reduced motion: explicit animation disable for `prefers-reduced-motion: reduce`.
+- Mobile/narrow: existing min-width gating (`@media (min-width: 1101px)`) remains in place.
+
+## Netlify/Vitrine confirmation
+- No sync/copy to published.
+- No edit in `/home/sanghop/axis/axis-niddhi-published`.
+- Published repo check remained unchanged in this sprint (`main...origin/main [ahead 2]`).
+
+## Forbidden-scope confirmation
+- No CSL/metadata/TCC/SP10/SP11/DeepL/translation changes.
+- No `.gitignore` changes.
+
+## Recommendation
+Proceed with:
+
+`#FlagFix_093 — LABZ post-polish Cloudflare visual review`
+
+## No-change confirmations
+- No deploy/manual upload
+- No Netlify promotion
+- No build/pipeline run
+- No published repo modifications

--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -1125,9 +1125,9 @@ body[data-theme="stardust"] #labz-banner {
 
   body[data-theme="stardust"] .labz-ambient-side {
     position: fixed;
-    top: 6rem;
-    bottom: 5rem;
-    width: 156px;
+    top: 7rem;
+    bottom: 6rem;
+    width: 128px;
     pointer-events: none;
   }
 
@@ -1138,11 +1138,11 @@ body[data-theme="stardust"] #labz-banner {
     background-position: center;
     background-repeat: no-repeat;
     background-size: contain;
-    opacity: 0.44;
+    opacity: 0.28;
   }
 
   body[data-theme="stardust"] .labz-ambient-side-left {
-    left: max(1rem, calc((100vw - 840px) / 2 - 194px));
+    left: max(1rem, calc((100vw - 840px) / 2 - 172px));
   }
 
   body[data-theme="stardust"] .labz-ambient-side-left::before {
@@ -1150,7 +1150,7 @@ body[data-theme="stardust"] #labz-banner {
   }
 
   body[data-theme="stardust"] .labz-ambient-side-right {
-    right: max(1rem, calc((100vw - 840px) / 2 - 194px));
+    right: max(1rem, calc((100vw - 840px) / 2 - 172px));
   }
 
   body[data-theme="stardust"] .labz-ambient-side-right::before {
@@ -1160,15 +1160,15 @@ body[data-theme="stardust"] #labz-banner {
   body[data-theme="stardust"] .labz-ambient-motif {
     position: absolute;
     display: block;
-    width: 56px;
-    height: 92px;
-    border: 1px solid rgba(0, 255, 65, 0.18);
+    width: 48px;
+    height: 80px;
+    border: 1px solid rgba(0, 255, 65, 0.1);
     border-radius: 72% 6% 72% 6%;
     background:
       linear-gradient(135deg, rgba(0, 255, 65, 0.12), rgba(0, 230, 118, 0.02) 58%, transparent 60%),
       linear-gradient(90deg, transparent 47%, rgba(0, 255, 65, 0.16) 49%, transparent 52%);
-    box-shadow: 0 0 20px rgba(0, 255, 65, 0.035);
-    opacity: 0.16;
+    box-shadow: 0 0 14px rgba(0, 255, 65, 0.02);
+    opacity: 0.09;
     transform-origin: 50% 90%;
   }
 
@@ -1210,24 +1210,36 @@ body[data-theme="stardust"] #labz-banner {
 
   @media (prefers-reduced-motion: no-preference) {
     body[data-theme="stardust"] .labz-ambient-motif {
-      animation: labzAmbientFloat 12s ease-in-out infinite alternate;
+      animation: labzAmbientFloat 18s ease-in-out infinite alternate;
     }
 
     body[data-theme="stardust"] .labz-ambient-motif:nth-child(2) {
-      animation-duration: 15s;
+      animation-duration: 22s;
       animation-delay: -4s;
     }
 
     body[data-theme="stardust"] .labz-ambient-motif:nth-child(3) {
-      animation-duration: 18s;
+      animation-duration: 26s;
       animation-delay: -7s;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    body[data-theme="stardust"] .labz-ambient-motif {
+      animation: none;
     }
   }
 }
 
 @keyframes labzAmbientFloat {
   from { margin-top: 0; }
-  to { margin-top: 12px; }
+  to { margin-top: 6px; }
+}
+
+@media print {
+  .labz-ambient-layer {
+    display: none !important;
+  }
 }
 
 /* ── END FF-013 ── */

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -1125,9 +1125,9 @@ body[data-theme="stardust"] #labz-banner {
 
   body[data-theme="stardust"] .labz-ambient-side {
     position: fixed;
-    top: 6rem;
-    bottom: 5rem;
-    width: 156px;
+    top: 7rem;
+    bottom: 6rem;
+    width: 128px;
     pointer-events: none;
   }
 
@@ -1138,11 +1138,11 @@ body[data-theme="stardust"] #labz-banner {
     background-position: center;
     background-repeat: no-repeat;
     background-size: contain;
-    opacity: 0.44;
+    opacity: 0.28;
   }
 
   body[data-theme="stardust"] .labz-ambient-side-left {
-    left: max(1rem, calc((100vw - 840px) / 2 - 194px));
+    left: max(1rem, calc((100vw - 840px) / 2 - 172px));
   }
 
   body[data-theme="stardust"] .labz-ambient-side-left::before {
@@ -1150,7 +1150,7 @@ body[data-theme="stardust"] #labz-banner {
   }
 
   body[data-theme="stardust"] .labz-ambient-side-right {
-    right: max(1rem, calc((100vw - 840px) / 2 - 194px));
+    right: max(1rem, calc((100vw - 840px) / 2 - 172px));
   }
 
   body[data-theme="stardust"] .labz-ambient-side-right::before {
@@ -1160,15 +1160,15 @@ body[data-theme="stardust"] #labz-banner {
   body[data-theme="stardust"] .labz-ambient-motif {
     position: absolute;
     display: block;
-    width: 56px;
-    height: 92px;
-    border: 1px solid rgba(0, 255, 65, 0.18);
+    width: 48px;
+    height: 80px;
+    border: 1px solid rgba(0, 255, 65, 0.1);
     border-radius: 72% 6% 72% 6%;
     background:
       linear-gradient(135deg, rgba(0, 255, 65, 0.12), rgba(0, 230, 118, 0.02) 58%, transparent 60%),
       linear-gradient(90deg, transparent 47%, rgba(0, 255, 65, 0.16) 49%, transparent 52%);
-    box-shadow: 0 0 20px rgba(0, 255, 65, 0.035);
-    opacity: 0.16;
+    box-shadow: 0 0 14px rgba(0, 255, 65, 0.02);
+    opacity: 0.09;
     transform-origin: 50% 90%;
   }
 
@@ -1210,24 +1210,36 @@ body[data-theme="stardust"] #labz-banner {
 
   @media (prefers-reduced-motion: no-preference) {
     body[data-theme="stardust"] .labz-ambient-motif {
-      animation: labzAmbientFloat 12s ease-in-out infinite alternate;
+      animation: labzAmbientFloat 18s ease-in-out infinite alternate;
     }
 
     body[data-theme="stardust"] .labz-ambient-motif:nth-child(2) {
-      animation-duration: 15s;
+      animation-duration: 22s;
       animation-delay: -4s;
     }
 
     body[data-theme="stardust"] .labz-ambient-motif:nth-child(3) {
-      animation-duration: 18s;
+      animation-duration: 26s;
       animation-delay: -7s;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    body[data-theme="stardust"] .labz-ambient-motif {
+      animation: none;
     }
   }
 }
 
 @keyframes labzAmbientFloat {
   from { margin-top: 0; }
-  to { margin-top: 12px; }
+  to { margin-top: 6px; }
+}
+
+@media print {
+  .labz-ambient-layer {
+    display: none !important;
+  }
 }
 
 /* ── END FF-013 ── */


### PR DESCRIPTION
## Summary

Adds #FlagFix_092: minimal CSS-only LABZ visual polish for the production/Cloudflare preview surface.

## Files changed

- pipeline/13-ssg/static/css/style.css
- pipeline/13-static-site/css/style.css
- docs/FlagFix/FLAGFIX_092_LABZ_MINIMAL_VISUAL_POLISH_CLOUDFLARE_ONLY.md

## Scope

CSS-only patch.

Path scope:

```text
PATH_SCOPE_OK
```

## Published/Vitrine

`/home/sanghop/axis/axis-niddhi-published` was not modified and remains:

```text
main...origin/main [ahead 2]
```

## Next

```text
#FlagFix_093 — LABZ post-polish Cloudflare visual review
```

## Safety

No deploy.
No Netlify upload.
No sync/copy to published.
No build/pipeline run.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No DeepL call.
No translation.
No .gitignore changes.
No Netlify/Vitrine promotion.