### PR TITLE
docs(flagfix): snapshot Vitrine before LABZ promotion

### DIFF
--- a/docs/FlagFix/FLAGFIX_096_LABZ_PROMOTION_SNAPSHOT_BEFORE_REAL_COPY.md
+++ b/docs/FlagFix/FLAGFIX_096_LABZ_PROMOTION_SNAPSHOT_BEFORE_REAL_COPY.md
@@ -1,0 +1,73 @@
+# #FlagFix_096 — LABZ Promotion Snapshot Before Real Copy
+
+## Purpose
+Create a rollback/safety snapshot of the current published static payload before any future LABZ real copy.
+
+## Source checkpoint
+- `checkpoint/flagfix-095-labz-netlify-promotion-dry-run-20260519`
+
+## Snapshot base path
+- `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_096_labz_pre_promotion_20260519_200424`
+
+## Snapshot files created
+- `published_git_status_sb.txt`
+- `published_git_log_20.txt`
+- `published_git_diff_stat.txt`
+- `published_git_diff_name_status.txt`
+- `published_HEAD.txt`
+- `published_static_file_list.txt`
+- `published_static_sha256_manifest.txt`
+- `published_static_size.txt`
+- `published_static_file_count.txt`
+- `published_pipeline_13_static_site_pre_labz_promotion.tar.gz`
+- `published_pipeline_13_static_site_pre_labz_promotion.tar.gz.sha256`
+- `tarball_listing.txt`
+- `tarball_listing_count.txt`
+
+## Published repo state (read-only)
+- `git status -sb`: `## main...origin/main [ahead 2]`
+- published `HEAD`: `5da4e599abb0acc7d561eb8b788c489c63238296`
+
+## Published static payload snapshot metrics
+- file count: `3082`
+- size: `807M`
+
+## Tarball snapshot
+- tarball path:  
+  `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_096_labz_pre_promotion_20260519_200424/published_pipeline_13_static_site_pre_labz_promotion.tar.gz`
+- tarball SHA256:  
+  `bcd801e0a4e74026e377107f262072f9b5f775972a5814f4e5d2cb903b74c6b4`
+- tar listing line count: `3846`
+
+## Re-grounded dry-run signals (from #096 rerun)
+- LABZ missing-from-published path count: `3`
+- assets-only dry-run output line count: `8`
+- reference-files dry-run output line count: `6`
+
+## Real-copy status
+- No real copy/sync happened (`rsync -n` dry-run only).
+- No deploy.
+- No Netlify upload.
+
+## Published repo safety confirmation
+- `axis-niddhi-published` was not modified by this sprint.
+- post-snapshot status remains `## main...origin/main [ahead 2]`.
+
+## Rollback note
+If a future LABZ promotion fails or regresses presentation, this tarball snapshot can restore the current published static payload baseline.
+
+## Recommendation
+`READY_FOR_REAL_COPY_WITH_APPROVAL`
+
+## Next sprint recommendation
+`#FlagFix_097 — LABZ real copy to published payload`
+
+## No-change confirmations
+- No deploy
+- No Netlify upload
+- No sync/copy production -> published
+- No edits to website/CSS/LABZ/Bodhi/flower files
+- No build/pipeline run
+- No DeepL/translation
+- No CSL/metadata/TCC/SP10/SP11 changes
+- No `.gitignore` changes


### PR DESCRIPTION
## Summary

Adds #FlagFix_096: external rollback snapshot before any real LABZ promotion copy.

## Snapshot

Snapshot base:

```text
/home/sanghop/axis/vitrine-safety-snapshots/flagfix_096_labz_pre_promotion_20260519_200424
```

Tarball:

```text
/home/sanghop/axis/vitrine-safety-snapshots/flagfix_096_labz_pre_promotion_20260519_200424/published_pipeline_13_static_site_pre_labz_promotion.tar.gz
```

SHA256:

```text
bcd801e0a4e74026e377107f262072f9b5f775972a5814f4e5d2cb903b74c6b4
```

## Result

- Published static file count: 3082
- Missing LABZ path count: 3
- Recommendation: READY_FOR_REAL_COPY_WITH_APPROVAL

## Next

```text
#FlagFix_097 — LABZ real copy to published payload
```

## Safety

No deploy.
No Netlify upload.
No real sync/copy.
Dry-run only where used.
axis-niddhi-published unchanged.
No website/CSS/LABZ/Bodhi/flower edits.
No build/pipeline run.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.