### PR TITLE
docs(flagfix): record LABZ real copy to published payload

### DIFF
--- a/docs/FlagFix/FLAGFIX_097_LABZ_REAL_COPY_TO_PUBLISHED_PAYLOAD.md
+++ b/docs/FlagFix/FLAGFIX_097_LABZ_REAL_COPY_TO_PUBLISHED_PAYLOAD.md
@@ -1,0 +1,75 @@
+# #FlagFix_097 — LABZ Real Copy to Published Payload
+
+## Purpose
+Perform the minimal approved LABZ real copy from production static payload into published static payload, using #095 dry-run scope and #096 rollback snapshot.
+
+## Source checkpoint
+- `checkpoint/flagfix-096-labz-promotion-snapshot-before-real-copy-20260519`
+
+## Rollback snapshot verification
+- snapshot base:
+  - `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_096_labz_pre_promotion_20260519_200424`
+- tarball:
+  - `/home/sanghop/axis/vitrine-safety-snapshots/flagfix_096_labz_pre_promotion_20260519_200424/published_pipeline_13_static_site_pre_labz_promotion.tar.gz`
+- verified SHA256:
+  - `bcd801e0a4e74026e377107f262072f9b5f775972a5814f4e5d2cb903b74c6b4`
+
+## Approved copied path list
+From `/tmp/flagfix_097_labz_missing_from_published_rel.txt` (missing count `3`):
+
+- `assets/labz`
+- `assets/labz/labz-lily-right-mvp-01.webp`
+- `assets/labz/labz-ora-pro-nobis-left-mvp-01.webp`
+
+## Final dry-run before real copy
+- command output file:
+  - `/tmp/flagfix_097_rsync/final_assets_only_dry_run.txt`
+- line count:
+  - `8`
+- scope matched expectation (assets/labz only).
+
+## Real copy execution
+- command output file:
+  - `/tmp/flagfix_097_rsync/real_assets_only_copy.txt`
+- line count:
+  - `8`
+- copied scope:
+  - `assets/labz/`
+  - `assets/labz/labz-lily-right-mvp-01.webp`
+  - `assets/labz/labz-ora-pro-nobis-left-mvp-01.webp`
+
+## Copied file hash verification
+File:
+- `/tmp/flagfix_097_copied_file_hashes.txt`
+
+Summary:
+- directory presence check for `assets/labz`: `directory_ok`
+- file hash parity confirmed:
+  - `labz-lily-right-mvp-01.webp`
+    - production: `4e0d1c419bfabcb9a69309622a7378d20a583e01a4f1e8b0d3b45a92e6206bb0`
+    - published:  `4e0d1c419bfabcb9a69309622a7378d20a583e01a4f1e8b0d3b45a92e6206bb0`
+  - `labz-ora-pro-nobis-left-mvp-01.webp`
+    - production: `590ad14895dc5a394683d6f4b2a5bea174d50e5851a77a7e949038e87e4f1016`
+    - published:  `590ad14895dc5a394683d6f4b2a5bea174d50e5851a77a7e949038e87e4f1016`
+
+## Published repo status after copy
+- `git status -sb`: `## main...origin/main [ahead 2]`
+- `git diff --name-status`: no tracked diff surfaced
+- path scope guard: `PUBLISHED_PATH_SCOPE_OK`
+
+## Production repo status after copy
+- no production website file changes
+- only this report added in production repo
+
+## Explicit non-actions
+- no deploy
+- no Netlify upload
+- no build/pipeline run
+- no CSL/metadata/TCC/SP10/SP11/DeepL/translation changes
+- no `.gitignore` changes
+
+## Recommendation
+`READY_FOR_LOCAL_REVIEW_BEFORE_NETLIFY_UPLOAD`
+
+## Next sprint recommendation
+`#FlagFix_098 — LABZ published local review before Netlify upload`


### PR DESCRIPTION
## Summary

Adds #FlagFix_097: records the minimal real copy of approved LABZ payload files into the local published static payload.

## Copied paths

- `assets/labz`
- `assets/labz/labz-lily-right-mvp-01.webp`
- `assets/labz/labz-ora-pro-nobis-left-mvp-01.webp`

## Result

- Copied count: 3 approved missing paths
- Published status: `main...origin/main [ahead 2]`
- Path scope: `PUBLISHED_PATH_SCOPE_OK`
- Recommendation: `READY_FOR_LOCAL_REVIEW_BEFORE_NETLIFY_UPLOAD`

## Next

```text
#FlagFix_098 — LABZ published local review before Netlify upload
```

## Safety

No deploy.
No Netlify upload.
No build/pipeline run.
No production website file changes except the #097 report.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No DeepL call.
No translation.
No .gitignore changes.