### PR TITLE
docs(flagfix): review LABZ published payload locally

### DIFF
--- a/docs/FlagFix/FLAGFIX_098_LABZ_PUBLISHED_LOCAL_REVIEW_BEFORE_NETLIFY_UPLOAD.md
+++ b/docs/FlagFix/FLAGFIX_098_LABZ_PUBLISHED_LOCAL_REVIEW_BEFORE_NETLIFY_UPLOAD.md
@@ -1,0 +1,77 @@
+# #FlagFix_098 — LABZ Published Local Review Before Netlify Upload
+
+## Purpose
+Review the local published payload after #097 LABZ copy, before any Netlify upload.
+
+## Source checkpoint
+- `checkpoint/flagfix-097-labz-real-copy-to-published-payload-20260519`
+
+## Published repo status
+- `git status -sb`: `## main...origin/main [ahead 2]`
+- `git diff --name-status`: no tracked diff output
+
+## Copied LABZ paths reviewed
+- `assets/labz/labz-lily-right-mvp-01.webp`
+- `assets/labz/labz-ora-pro-nobis-left-mvp-01.webp`
+
+## Hash verification summary
+From `/tmp/flagfix_098_labz_hashes.txt`, source and published hashes match for both files:
+
+- `labz-lily-right-mvp-01.webp`: `4e0d1c419bfabcb9a69309622a7378d20a583e01a4f1e8b0d3b45a92e6206bb0`
+- `labz-ora-pro-nobis-left-mvp-01.webp`: `590ad14895dc5a394683d6f4b2a5bea174d50e5851a77a7e949038e87e4f1016`
+
+## Local server review
+- server port used: `8098`
+- server started from:
+  - `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site`
+- server stopped successfully after checks (`server stopped` confirmed).
+
+## HTTP status summary
+From `/tmp/flagfix_098_http/status_summary.txt`:
+
+- `GET /` -> `200 OK`
+- `GET /welcome.html` -> `200 OK`
+- `GET /contribute.html` -> `200 OK`
+- `GET /assets/labz/labz-lily-right-mvp-01.webp` -> `200 OK` (`image/webp`)
+- `GET /assets/labz/labz-ora-pro-nobis-left-mvp-01.webp` -> `200 OK` (`image/webp`)
+- `GET /css/style.css` -> `200 OK`
+
+## CTA/content checks
+From `/tmp/flagfix_098_http/cta_hits.txt`:
+- Root and welcome contain:
+  - `ENTER ARCHIVE`
+  - `CONTRIBUTE`
+  - `ACESSAR ACERVO`
+  - `COLABORAR`
+
+LABZ marker hits in fetched root/welcome/contribute HTML:
+- `/tmp/flagfix_098_http/labz_hits.txt`: `0` lines
+- Interpretation: LABZ rendering remains theme/toggle/CSS-path dependent, not explicit text in landing HTML.
+
+## LABZ reference checks in published payload
+From `/tmp/flagfix_098_published_labz_reference_context.txt` (`31` lines):
+- Published `css/style.css` contains stardust + labz button/theme rules.
+- No broad file changes were introduced in this sprint.
+
+## LABZ image technical checks
+From `/tmp/flagfix_098_labz_file_types.txt` and `/tmp/flagfix_098_labz_file_sizes.txt`:
+- both assets are valid WebP (`RIFF ... Web/P image`)
+- sizes:
+  - lily: `84K`
+  - ora-pro-nobis: `88K`
+
+## Published path scope result
+- `PUBLISHED_PATH_SCOPE_OK`
+
+## Non-action confirmation
+- No Netlify upload performed
+- No deploy performed
+- No push performed
+- No build/pipeline run
+- No file modifications in this sprint
+
+## Recommendation
+`READY_FOR_MANUAL_VISUAL_REVIEW`
+
+## Next sprint recommendation
+`#FlagFix_099 — LABZ manual visual review before Netlify upload`


### PR DESCRIPTION
## Summary

Adds #FlagFix_098: local published payload review after the minimal LABZ copy and before any Netlify upload.

## Result

Recommendation:

```text
READY_FOR_MANUAL_VISUAL_REVIEW
```

HTTP checks:

- `/`: 200 OK
- `/welcome.html`: 200 OK
- `/contribute.html`: 200 OK
- `/assets/labz/labz-lily-right-mvp-01.webp`: 200 OK / image-webp
- `/assets/labz/labz-ora-pro-nobis-left-mvp-01.webp`: 200 OK / image-webp
- `/css/style.css`: 200 OK

Hash verification:

- `labz-lily-right-mvp-01.webp`: source and published match
- `labz-ora-pro-nobis-left-mvp-01.webp`: source and published match

Path scope:

```text
PUBLISHED_PATH_SCOPE_OK
```

## Next

```text
#FlagFix_099 — LABZ manual visual review before Netlify upload
```

## Safety

No deploy.
No Netlify upload.
No push.
No sync/copy.
No build/pipeline run.
No website/CSS/LABZ/Bodhi/flower edits.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.