### PR TITLE
docs(flagfix): record LABZ manual visual review hold

### DIFF
--- a/docs/FlagFix/FLAGFIX_099_LABZ_MANUAL_VISUAL_REVIEW_BEFORE_NETLIFY_UPLOAD.md
+++ b/docs/FlagFix/FLAGFIX_099_LABZ_MANUAL_VISUAL_REVIEW_BEFORE_NETLIFY_UPLOAD.md
@@ -1,0 +1,59 @@
+# #FlagFix_099 — LABZ Manual Visual Review Before Netlify Upload
+
+## Purpose
+Record the manual visual review decision gate for local published LABZ payload before any Netlify upload.
+
+## Source checkpoint
+- `checkpoint/flagfix-098-labz-published-local-review-20260519`
+
+## Reviewed local payload path
+- `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site`
+
+## Published repo status
+- `git status -sb`: `## main...origin/main [ahead 2]`
+- `git diff --name-status`: no tracked diff output
+
+## Reviewed URLs/paths
+- `http://127.0.0.1:8099/`
+- `http://127.0.0.1:8099/welcome.html`
+- `http://127.0.0.1:8099/contribute.html`
+- reviewed LABZ assets:
+  - `assets/labz/labz-lily-right-mvp-01.webp`
+  - `assets/labz/labz-ora-pro-nobis-left-mvp-01.webp`
+
+## Manual checklist result
+- Root page loads normally: `PENDING HUMAN CONFIRMATION`
+- Welcome page loads normally: `PENDING HUMAN CONFIRMATION`
+- Contribute page loads normally: `PENDING HUMAN CONFIRMATION`
+- LABZ flowers appear where expected: `PENDING HUMAN CONFIRMATION`
+- Flowers do not block reading: `PENDING HUMAN CONFIRMATION`
+- Flowers do not cover CTA buttons: `PENDING HUMAN CONFIRMATION`
+- Flowers do not feel visually broken: `PENDING HUMAN CONFIRMATION`
+- Mobile/narrow viewport acceptable: `PENDING HUMAN CONFIRMATION`
+- CTA surface remains OK: `PENDING HUMAN CONFIRMATION`
+- Bodhi transparent asset remains acceptable: `PENDING HUMAN CONFIRMATION`
+
+## Manual visual decision
+`MANUAL_VISUAL_HOLD`
+
+Reason:
+- No explicit human visual PASS was provided within this sprint.
+- Upload gate should remain closed until a human reviewer confirms checklist items above.
+
+## Recommendation
+`HOLD_FOR_LABZ_DESIGN_POLISH`
+
+## Next sprint recommendation
+`#FlagFix_100 — LABZ design polish follow-up`
+
+## Non-action confirmation
+- No deploy
+- No Netlify upload
+- No push
+- No build/pipeline run
+- No sync/copy actions
+- No edits to `axis-niddhi-published`
+- No website/CSS/LABZ/Bodhi/flower file changes
+- No DeepL/translation
+- No CSL/metadata/TCC/SP10/SP11 changes
+- No `.gitignore` changes


### PR DESCRIPTION
## Summary

Adds #FlagFix_099: manual visual review decision for LABZ in the local published payload before any Netlify upload.

## Decision

```text
MANUAL_VISUAL_HOLD
```

## Recommendation

```text
HOLD_FOR_LABZ_DESIGN_POLISH
```

## Published status

```text
main...origin/main [ahead 2]
```

No tracked diff output.

## Next

```text
#FlagFix_100 — LABZ design polish follow-up
```

## Safety

No deploy.
No Netlify upload.
No push.
No build/pipeline run.
No sync/copy.
No axis-niddhi-published modifications.
No website/CSS/LABZ/Bodhi/flower file edits.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.