### PR TITLE
docs(flagfix): approve LABZ Netlify upload override

### DIFF
--- a/docs/FlagFix/FLAGFIX_100_LABZ_NETLIFY_UPLOAD_DECISION_OVERRIDE.md
+++ b/docs/FlagFix/FLAGFIX_100_LABZ_NETLIFY_UPLOAD_DECISION_OVERRIDE.md
@@ -1,0 +1,54 @@
+# #FlagFix_100 — LABZ Netlify Upload Decision Override
+
+## Purpose
+Record explicit human override/approval to proceed with LABZ Netlify upload readiness despite #099 manual visual hold notes.
+
+## Source checkpoint
+- `checkpoint/flagfix-099-labz-manual-visual-review-hold-20260519`
+
+## Previous decision from #099
+- `MANUAL_VISUAL_HOLD`
+
+## Human override rationale
+- LABZ is an easter-egg button/path.
+- LABZ exposure is extremely low visibility in normal usage.
+- Flower visual notes are minor/non-blocking.
+- Acceptable to proceed toward Netlify promotion decision.
+
+## Published repo status (read-only)
+- `git status -sb`: `## main...origin/main [ahead 2]`
+- no tracked diff output from `git diff --name-status`
+
+## LABZ payload confirmation in published static
+Confirmed existing:
+- `assets/labz/labz-lily-right-mvp-01.webp`
+- `assets/labz/labz-ora-pro-nobis-left-mvp-01.webp`
+- `css/style.css`
+- `index.html`
+- `welcome.html`
+- `contribute.html`
+
+Optional hash confirmation:
+- lily: `4e0d1c419bfabcb9a69309622a7378d20a583e01a4f1e8b0d3b45a92e6206bb0`
+- ora-pro-nobis: `590ad14895dc5a394683d6f4b2a5bea174d50e5851a77a7e949038e87e4f1016`
+
+## Override decision
+Human operator override accepted: previous hold is non-blocking for upload decision progression.
+
+## Final recommendation
+`READY_FOR_MANUAL_NETLIFY_UPLOAD`
+
+## Next sprint recommendation
+`#FlagFix_101 — LABZ manual Netlify upload and public smoke check`
+
+## No-change confirmations
+- No deploy
+- No Netlify upload
+- No push
+- No build/pipeline run
+- No sync/copy
+- No `axis-niddhi-published` modifications
+- No website/CSS/LABZ/Bodhi/flower edits
+- No DeepL/translation
+- No CSL/metadata/TCC/SP10/SP11 changes
+- No `.gitignore` changes


### PR DESCRIPTION
## Summary

Adds #FlagFix_100: records the explicit human override that LABZ may proceed to manual Netlify upload despite the #099 visual hold.

## Decision

Human override accepted.

This supersedes the #099 hold as non-blocking for upload decision progression.

## Recommendation

```text
READY_FOR_MANUAL_NETLIFY_UPLOAD
```

## Published status

```text
main...origin/main [ahead 2]
```

## Next

```text
#FlagFix_101 — LABZ manual Netlify upload and public smoke check
```

## Safety

No deploy.
No Netlify upload.
No push.
No build/pipeline.
No sync/copy.
No axis-niddhi-published modifications.
No website/CSS/LABZ/Bodhi/flower edits.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.