### PR TITLE
docs(flagfix): record LABZ Netlify public smoke pass

### DIFF
--- a/docs/FlagFix/FLAGFIX_101_LABZ_NETLIFY_UPLOAD_AND_PUBLIC_SMOKE_CHECK.md
+++ b/docs/FlagFix/FLAGFIX_101_LABZ_NETLIFY_UPLOAD_AND_PUBLIC_SMOKE_CHECK.md
@@ -1,0 +1,79 @@
+# #FlagFix_101 — LABZ Netlify Upload and Public Smoke Check
+
+## Purpose
+Record public smoke validation after manual Netlify upload decision override for LABZ payload.
+
+## Source checkpoint
+- `checkpoint/flagfix-100-labz-netlify-upload-override-20260519`
+
+## Manual upload confirmation context
+- Human-directed upload source folder:
+  - `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site`
+- This sprint executed read-only public checks only (no upload by agent).
+
+## Public URLs checked
+- `https://niddhi.netlify.app/`
+- `https://niddhi.netlify.app/welcome`
+- `https://niddhi.netlify.app/welcome.html`
+- `https://niddhi.netlify.app/contribute`
+- `https://niddhi.netlify.app/contribute.html`
+- `https://niddhi.netlify.app/assets/labz/labz-lily-right-mvp-01.webp`
+- `https://niddhi.netlify.app/assets/labz/labz-ora-pro-nobis-left-mvp-01.webp`
+- `https://niddhi.netlify.app/css/style.css`
+
+## HTTP status summary
+From `/tmp/flagfix_101_netlify/http_status_summary.txt`:
+- all checked URLs returned successful responses (`HTTP/2 200`)
+- asset content-types correct:
+  - `image/webp` for both LABZ flowers
+  - `text/css` for stylesheet
+
+## CTA and contribute-copy checks
+From `/tmp/flagfix_101_netlify/cta_hits.txt`:
+- CTA set present in public root/welcome:
+  - `ENTER ARCHIVE`
+  - `CONTRIBUTE`
+  - `ACESSAR ACERVO`
+  - `COLABORAR`
+
+From `/tmp/flagfix_101_netlify/contribute_copy_hits.txt`:
+- neutral copy present:
+  - `AXIS-NIDDHI Collaboration Surface`
+- legacy blocked copy absent:
+  - `AXIS-NIDDHI Cloudflare Staging` not found
+
+## LABZ reference checks in public HTML
+From `/tmp/flagfix_101_netlify/labz_reference_hits.txt`:
+- `0` lines
+- Interpretation: LABZ behavior remains theme/toggle/CSS-path dependent, not explicit textual markers in landing HTML.
+
+## LABZ asset hash checks (public vs local published)
+From `/tmp/flagfix_101_netlify/labz_asset_hashes.txt`:
+- `labz-lily-right-mvp-01.webp` hash matches:
+  - `4e0d1c419bfabcb9a69309622a7378d20a583e01a4f1e8b0d3b45a92e6206bb0`
+- `labz-ora-pro-nobis-left-mvp-01.webp` hash matches:
+  - `590ad14895dc5a394683d6f4b2a5bea174d50e5851a77a7e949038e87e4f1016`
+
+File-type check (`/tmp/flagfix_101_netlify/labz_asset_file_types.txt`):
+- both downloaded public assets are valid WebP files.
+
+## Public smoke decision
+`PUBLIC_SMOKE_PASS`
+
+## Recommendation
+`LABZ_NETLIFY_PROMOTION_COMPLETE`
+
+## Next sprint recommendation
+`#FlagFix_102 — LABZ Netlify promotion closure index`
+
+## No-change confirmations
+- no automatic deploy
+- no automatic Netlify upload by agent
+- no push
+- no build/pipeline run
+- no sync/copy
+- no `axis-niddhi-published` modifications
+- no website/CSS/LABZ/Bodhi/flower edits
+- no DeepL/translation
+- no CSL/metadata/TCC/SP10/SP11 changes
+- no `.gitignore` changes


### PR DESCRIPTION
## Summary

Adds #FlagFix_101: records the manual Netlify upload and public smoke check for LABZ.

## Public smoke decision

```text
PUBLIC_SMOKE_PASS
```

## Recommendation

```text
LABZ_NETLIFY_PROMOTION_COMPLETE
```

## Public HTTP summary

All checked Netlify URLs returned HTTP 200:

- /
- /welcome
- /welcome.html
- /contribute
- /contribute.html
- /assets/labz/labz-lily-right-mvp-01.webp
- /assets/labz/labz-ora-pro-nobis-left-mvp-01.webp
- /css/style.css

## LABZ public asset hash result

```text
labz-lily-right-mvp-01.webp public == local published
4e0d1c419bfabcb9a69309622a7378d20a583e01a4f1e8b0d3b45a92e6206bb0

labz-ora-pro-nobis-left-mvp-01.webp public == local published
590ad14895dc5a394683d6f4b2a5bea174d50e5851a77a7e949038e87e4f1016
```

## Next

```text
#FlagFix_102 — LABZ Netlify promotion closure index
```

## Safety

No automatic deploy.
No automatic Netlify upload by agent.
No push.
No build/pipeline run.
No sync/copy.
No axis-niddhi-published modifications.
No website/CSS/LABZ/Bodhi/flower edits.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.