### PR TITLE
docs(flagfix): close LABZ Netlify promotion block

### DIFF
--- a/docs/FlagFix/FLAGFIX_088_101_LABZ_NETLIFY_PROMOTION_CLOSURE_INDEX.md
+++ b/docs/FlagFix/FLAGFIX_088_101_LABZ_NETLIFY_PROMOTION_CLOSURE_INDEX.md
@@ -1,0 +1,89 @@
+# #FlagFix_102 — LABZ Netlify Promotion Closure Index
+
+Date: 2026-05-19
+
+## Scope
+This closure index covers `#088` through `#101`.
+
+## Final decision
+`LABZ_NETLIFY_PROMOTION_COMPLETE`
+
+## Final public smoke result
+`PUBLIC_SMOKE_PASS`
+
+Public URL:
+`https://niddhi.netlify.app/`
+
+## Final interpretation
+- LABZ has been promoted to Netlify.
+- LABZ remains an experimental, low-visibility, easter-egg collaboration layer.
+- Flower visuals were reviewed during the block.
+- `#099` recorded `MANUAL_VISUAL_HOLD`.
+- `#100` recorded human override accepting flower notes as non-blocking.
+- `#101` confirmed successful public Netlify smoke checks.
+- No further LABZ polish is a blocker for the current Vitrine state.
+
+## Important LABZ asset hashes (#101)
+- `labz-lily-right-mvp-01.webp`
+  - `4e0d1c419bfabcb9a69309622a7378d20a583e01a4f1e8b0d3b45a92e6206bb0`
+- `labz-ora-pro-nobis-left-mvp-01.webp`
+  - `590ad14895dc5a394683d6f4b2a5bea174d50e5851a77a7e949038e87e4f1016`
+
+## Block chronology
+| FlagFix | Purpose | Result | Notes |
+|---|---|---|---|
+| #088 | Structural migration audit | Needs visual review | Payload gap, no hard host lock-in |
+| #089 | Visual checklist definition | Checklist ready | Promotion held pending review |
+| #090 | Cloudflare visual review | Visual hold | Needed design polish |
+| #091 | Design polish plan | Ready for polish patch | Cloudflare-only patch path |
+| #092 | Minimal polish patch | Applied | CSS-only, reversible |
+| #093 | Post-polish review | Pass with minor notes | Promotion planning allowed |
+| #094 | Controlled promotion plan | Ready for dry-run only | Scope and safeguards documented |
+| #095 | Promotion dry-run | Ready for snapshot | No real copy performed |
+| #096 | Pre-copy rollback snapshot | Ready for real copy with approval | Snapshot + tarball safety baseline |
+| #097 | Real LABZ copy to published | Ready for local review | Minimal scoped copy completed |
+| #098 | Published local review | Ready for manual visual review | Local HTTP/content/hash checks passed |
+| #099 | Manual visual review gate | Hold | Flower visuals noted |
+| #100 | Upload decision override | Ready for manual upload | Human override accepted |
+| #101 | Manual upload + public smoke | Public smoke pass | Promotion complete on Netlify |
+
+## Checkpoints (#088–#101)
+- `checkpoint/flagfix-088-labz-netlify-migration-structural-audit-20260519`
+- `checkpoint/flagfix-089-labz-visual-design-review-checklist-20260519`
+- `checkpoint/flagfix-090-labz-cloudflare-visual-review-hold-20260519`
+- `checkpoint/flagfix-091-labz-design-polish-plan-20260519`
+- `checkpoint/flagfix-092-labz-minimal-visual-polish-20260519`
+- `checkpoint/flagfix-093-labz-post-polish-cloudflare-review-20260519`
+- `checkpoint/flagfix-094-labz-controlled-netlify-promotion-plan-20260519`
+- `checkpoint/flagfix-095-labz-netlify-promotion-dry-run-20260519`
+- `checkpoint/flagfix-096-labz-promotion-snapshot-before-real-copy-20260519`
+- `checkpoint/flagfix-097-labz-real-copy-to-published-payload-20260519`
+- `checkpoint/flagfix-098-labz-published-local-review-20260519`
+- `checkpoint/flagfix-099-labz-manual-visual-review-hold-20260519`
+- `checkpoint/flagfix-100-labz-netlify-upload-override-20260519`
+- `checkpoint/flagfix-101-labz-netlify-public-smoke-pass-20260519`
+
+## Final recommendations
+- LABZ Netlify promotion can be considered closed.
+- Future LABZ work should run as a new design/polish sprint and not block current Vitrine operation.
+- Keep Cloudflare as the experimental surface.
+- Keep Netlify Vitrine stable and promote only deliberate, reviewed bundles.
+
+Recommended next sprint:
+`#FlagFix_103 — post-LABZ Vitrine/published repo reconciliation`
+
+Reason:
+`axis-niddhi-published` remains locally ahead, and pull/status messaging should be reconciled through safe PR/cleanup/documentation handling.
+
+## Explicit non-actions
+- Documentation-only closure in this sprint.
+- No deploy.
+- No Netlify upload.
+- No push.
+- No build/pipeline run.
+- No sync/copy.
+- No `axis-niddhi-published` file modifications.
+- No website/CSS/LABZ/Bodhi/flower edits.
+- No DeepL/translation.
+- No CSL/metadata/TCC/SP10/SP11 changes.
+- No `.gitignore` changes.


### PR DESCRIPTION
## Summary

Adds #FlagFix_102: closure index for the LABZ Netlify promotion block covering #088–#101.

## Final decision

```text
LABZ_NETLIFY_PROMOTION_COMPLETE
```

## Public smoke result

```text
PUBLIC_SMOKE_PASS
```

## Interpretation

LABZ has been promoted to Netlify as an experimental, low-visibility easter-egg collaboration layer.

#099 recorded the visual hold.
#100 recorded the human override accepting flower visual notes as non-blocking.
#101 confirmed public Netlify smoke pass.

Future LABZ polish is not blocking the current Vitrine state.

## Next

```text
#FlagFix_103 — post-LABZ Vitrine/published repo reconciliation
```

## Safety

Documentation only.
No deploy.
No Netlify upload.
No push beyond this PR branch.
No build/pipeline run.
No sync/copy.
No axis-niddhi-published modifications.
No website/CSS/LABZ/Bodhi/flower edits.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No Translation_Control_Center.csv changes.
No SP10/SP11 changes.
No .gitignore changes.