### PR TITLE
docs(flagfix): snapshot current Vitrine and Cloudflare surfaces

### DIFF
--- a/docs/FlagFix/FLAGFIX_106_CURRENT_VITRINE_CLOUDFLARE_SURFACE_STATUS_SNAPSHOT.md
+++ b/docs/FlagFix/FLAGFIX_106_CURRENT_VITRINE_CLOUDFLARE_SURFACE_STATUS_SNAPSHOT.md
@@ -1,0 +1,78 @@
+# #FlagFix_106 — Current Vitrine/Cloudflare Surface Status Snapshot
+
+Date: 2026-05-19  
+Workspace: `/home/sanghop/axis`
+
+## Source checkpoint
+`checkpoint/flagfix-105-vitrine-git-hygiene-closure-20260519`
+
+## Snapshot purpose
+Record a read-only post-closure status snapshot of:
+- local production/published workspace state; and
+- public Cloudflare/Netlify surfaces (root, welcome, contribute, and LABZ assets).
+
+## Production repo state
+- Repo: `/home/sanghop/axis/axis-niddhi-production`
+- Status: `main...origin/main`
+- Working tree: clean during this audit.
+- Latest checkpoint tag present: `checkpoint/flagfix-105-vitrine-git-hygiene-closure-20260519`.
+
+## Published repo state
+- Repo: `/home/sanghop/axis/axis-niddhi-published`
+- Status: `main...origin/main [ahead 2]`
+- Working tree: clean during this audit.
+- Ahead commits:
+  - `92f4c298f17008f4022c0267f1e64af14a1742a1`
+  - `5da4e599abb0acc7d561eb8b788c489c63238296`
+
+## Public surface matrix
+
+| URL | HTTP | Final URL | ENTER ARCHIVE | CONTRIBUTE | ACESSAR ACERVO | COLABORAR | Collaboration Surface | Cloudflare Staging |
+|---|---:|---|---|---|---|---|---|---|
+| `https://niddhi.pages.dev/` | 200 | `https://niddhi.pages.dev/welcome` | Yes | Yes | Yes | Yes | No | No |
+| `https://niddhi.pages.dev/welcome` | 200 | same | Yes | Yes | Yes | Yes | No | No |
+| `https://niddhi.pages.dev/contribute` | 200 | same | No | No | No | No | Yes | No |
+| `https://niddhi.netlify.app/` | 200 | same | Yes | Yes | Yes | Yes | No | No |
+| `https://niddhi.netlify.app/welcome` | 200 | same | Yes | Yes | Yes | Yes | No | No |
+| `https://niddhi.netlify.app/contribute` | 200 | same | No | No | No | No | Yes | No |
+
+## CTA parity result
+Cloudflare and Netlify are aligned on landing CTA presence:
+- root/welcome have `ENTER ARCHIVE`, `CONTRIBUTE`, `ACESSAR ACERVO`, `COLABORAR`;
+- contribute pages do not expose landing CTA strings (expected for page role).
+
+## Contribute-copy parity result
+Both hosts serve contribute pages with:
+- `AXIS-NIDDHI Collaboration Surface` present;
+- `AXIS-NIDDHI Cloudflare Staging` absent.
+
+## LABZ asset public availability
+Checked:
+- `/assets/labz/labz-lily-right-mvp-01.webp`
+- `/assets/labz/labz-ora-pro-nobis-left-mvp-01.webp`
+
+Result:
+- Cloudflare: HTTP 200, `content-type: image/webp`
+- Netlify: HTTP 200, `content-type: image/webp`
+
+## Final snapshot decision
+`CURRENT_SURFACES_STATUS_SNAPSHOT_RECORDED`
+
+## Recommended next action
+`NO_IMMEDIATE_NEXT_FLAGFIX_REQUIRED`
+
+## Explicit no-change confirmations
+- Read-only/documentation-only snapshot.
+- No push.
+- No deploy.
+- No Netlify upload.
+- No commit in `axis-niddhi-published`.
+- No reset/rebase/merge.
+- No branch deletion.
+- No sync/copy.
+- No `axis-niddhi-published` modifications.
+- No production website file edits.
+- No build/pipeline run.
+- No DeepL/translation.
+- No CSL/metadata/TCC/SP10/SP11 changes.
+- No `.gitignore` changes.


### PR DESCRIPTION
## Summary

Adds #FlagFix_106: a read-only post-closure status snapshot of the current Cloudflare and Netlify public surfaces.

## Results

- Cloudflare root/welcome/contribute: PASS
- Netlify root/welcome/contribute: PASS
- CTA parity: PASS
- Contribute copy parity: PASS
- LABZ assets public availability: PASS on both hosts

## Final snapshot decision

```text
CURRENT_SURFACES_STATUS_SNAPSHOT_RECORDED
```

## Recommended next action

```text
NO_IMMEDIATE_NEXT_FLAGFIX_REQUIRED
```

## Safety

Documentation/read-only only.
No push from published.
No deploy.
No Netlify upload.
No commit in axis-niddhi-published.
No reset/rebase/merge.
No branch deletion.
No sync/copy.
No axis-niddhi-published modifications.
No production website edits.
No build/pipeline.
No DeepL call.
No translation.
No CSL changes.
No metadata CSV changes.
No TCC/SP10/SP11 changes.
No .gitignore changes.