### PR TITLE
docs(flagfix): record LABZ published reference layer fix

### DIFF
--- a/docs/FlagFix/FLAGFIX_107_LABZ_FLOWERS_NOT_RENDERING_PUBLISHED_TRIAGE.md
+++ b/docs/FlagFix/FLAGFIX_107_LABZ_FLOWERS_NOT_RENDERING_PUBLISHED_TRIAGE.md
@@ -1,0 +1,73 @@
+# #FlagFix_107 — LABZ Flowers Not Rendering in Published Payload (Triage)
+
+Date: 2026-05-19  
+Workspace: `/home/sanghop/axis`
+
+## Source checkpoint
+`checkpoint/flagfix-106-surface-status-snapshot-20260519`
+
+## Symptom
+With local serving of published payload (`/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site`), LABZ can be toggled but flower visuals do not appear.
+
+## Key conclusion
+This is **not Netlify-specific** (reproduced in local published payload behavior).
+
+## Production vs published LABZ inventory
+- Production labz/bodhi/flower path count: `8`
+- Published labz/bodhi/flower path count: `8`
+- Asset inventory is present on both sides for:
+  - `assets/labz/`
+  - `assets/labz/labz-lily-right-mvp-01.webp`
+  - `assets/labz/labz-ora-pro-nobis-left-mvp-01.webp`
+  - Bodhi assets
+
+## CSS reference comparison
+- `style.css` production vs published diff: `160` lines (`/tmp/flagfix_107_style_css_diff.txt`).
+- Production CSS contains explicit LABZ ambient rendering block:
+  - `.labz-ambient-layer`
+  - `@media (min-width: 1101px)`
+  - `body[data-theme="stardust"] .labz-ambient-side...`
+  - `background-image: url("../assets/labz/labz-ora-pro-nobis-left-mvp-01.webp")`
+  - `background-image: url("../assets/labz/labz-lily-right-mvp-01.webp")`
+- Published CSS **does not contain** this LABZ ambient rendering block (file jumps from previous section into FF-014 block where production has LABZ ambient layer rules).
+
+## HTML reference comparison
+- Landing files checked in production and published (`index.html`, `welcome.html`, `contribute.html`) have no LABZ ambient references by grep.
+- Additional check:
+  - Production `archive.html` includes `.labz-ambient-layer`.
+  - Published `archive.html` has LABZ button/toggle but no `.labz-ambient-layer` container.
+
+## Asset existence check
+- Published referenced LABZ assets extraction from file content produced no direct `assets/labz/...` hits in published static (`/tmp/flagfix_107_published_referenced_labz_assets.txt` empty).
+- Even so, assets exist on disk under `assets/labz/` in published.
+- Interpretation: assets are available, but reference/render layer is incomplete in published payload.
+
+## Likely root cause
+Published payload has a **reference/render-layer gap**:
+1. LABZ toggle logic exists (`js/main.js` and button present).
+2. LABZ flower assets exist.
+3. But published static is missing critical LABZ ambient CSS/markup needed to paint side flowers.
+
+## Root cause classification
+`LABZ_RENDERING_GAP_CONFIRMED_REFERENCE_LAYER_MISSING`
+
+## Recommendation for #108
+`#FlagFix_108 — promote LABZ reference layer to published payload`
+
+Expected #108 scope should focus on promoting the missing LABZ reference/render layer (CSS + required markup locations) into published static, with path-scope controls and no broad sync.
+
+## Explicit no-change confirmations
+- Documentation/read-only triage only.
+- No push.
+- No deploy.
+- No Netlify upload.
+- No commit in `axis-niddhi-published`.
+- No reset/rebase/merge.
+- No branch deletion.
+- No sync/copy.
+- No `axis-niddhi-published` modifications.
+- No production website edits.
+- No build/pipeline run.
+- No DeepL/translation.
+- No CSL/metadata/TCC/SP10/SP11 changes.
+- No `.gitignore` changes.

--- a/docs/FlagFix/FLAGFIX_108_PROMOTE_LABZ_REFERENCE_LAYER_TO_PUBLISHED.md
+++ b/docs/FlagFix/FLAGFIX_108_PROMOTE_LABZ_REFERENCE_LAYER_TO_PUBLISHED.md
@@ -1,0 +1,72 @@
+# #FlagFix_108 — Promote LABZ Reference Layer to Published
+
+Date: 2026-05-19  
+Source checkpoint: `checkpoint/flagfix-106-surface-status-snapshot-20260519`
+
+## #107 root cause
+`LABZ_RENDERING_GAP_CONFIRMED_REFERENCE_LAYER_MISSING`
+
+Published had LABZ assets and toggle, but was missing the LABZ reference/render layer on target files.
+
+## Files copied (narrow scope)
+- `/home/sanghop/axis/axis-niddhi-production/pipeline/13-static-site/css/style.css`
+  -> `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site/css/style.css`
+- `/home/sanghop/axis/axis-niddhi-production/pipeline/13-static-site/archive.html`
+  -> `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site/archive.html`
+
+## Pre-patch safety snapshot
+Snapshot path:
+`/home/sanghop/axis/vitrine-safety-snapshots/flagfix_108_labz_reference_layer_prepatch`
+
+Prepatch hashes (`/tmp/flagfix_108_prepatch_target_hashes.txt`):
+- `70ade3a8383594b7c7b32d342a4a8aa9870ac2b5233e39d0d2fb4911479cda87`  `style.css.pre108`
+- `df43a04bfc6518272977ccac598d63d3efb51dbd1e287373a9ddda2327dc21bb`  `archive.html.pre108`
+
+## Target parity validation
+- `/tmp/flagfix_108_style_css_parity.diff`: `0` lines
+- `/tmp/flagfix_108_archive_html_parity.diff`: `0` lines
+
+Result: both published target files now match production exactly.
+
+## LABZ reference check in published (post-patch)
+Confirmed in published:
+- `.labz-ambient-layer` and `.labz-ambient-side*` selectors in `css/style.css`
+- LABZ flower asset references:
+  - `labz-ora-pro-nobis-left-mvp-01.webp`
+  - `labz-lily-right-mvp-01.webp`
+- LABZ ambient markup present in `archive.html`.
+
+Evidence file:
+`/tmp/flagfix_108_published_labz_reference_check.txt`
+
+## Published path scope result
+Changed paths in published:
+- `pipeline/13-static-site/css/style.css`
+- `pipeline/13-static-site/archive.html`
+
+Scope gate result: `PUBLISHED_PATH_SCOPE_OK`
+
+## Local visual review
+Pending in this sprint (no local manual visual verification executed here).
+
+## Final decision
+`LABZ_REFERENCE_LAYER_PROMOTED_PENDING_LOCAL_VISUAL_REVIEW`
+
+## Recommended #109
+`#FlagFix_109 — LABZ published local visual review after reference-layer promotion`
+
+## No-change confirmations
+- No deploy.
+- No Netlify upload.
+- No push.
+- No build/pipeline run.
+- No DeepL/translation.
+- No CSL changes.
+- No metadata CSV changes.
+- No TCC/SP10/SP11 changes.
+- No `.gitignore` changes.
+- No broad sync.
+- Published changes limited to:
+  - `pipeline/13-static-site/css/style.css`
+  - `pipeline/13-static-site/archive.html`
+- Production changes limited to this #108 report.


### PR DESCRIPTION
## Summary

Records #FlagFix_107 and #FlagFix_108.

#107 confirmed that LABZ flowers were not rendering in the published/Vitrine payload because the reference/render layer was missing, even though LABZ assets existed.

#108 promoted only the missing LABZ reference layer to the published payload.

Published files copied outside this PR:
- `pipeline/13-static-site/css/style.css`
- `pipeline/13-static-site/archive.html`

## Validation

- Target parity diff counts:
  - `/tmp/flagfix_108_style_css_parity.diff`: `0`
  - `/tmp/flagfix_108_archive_html_parity.diff`: `0`
- Published path scope: `PUBLISHED_PATH_SCOPE_OK`
- LABZ references confirmed in published:
  - `.labz-ambient-layer`
  - `.labz-ambient-side*`
  - `labz-ora-pro-nobis-left-mvp-01.webp`
  - `labz-lily-right-mvp-01.webp`

## Decision

`LABZ_REFERENCE_LAYER_PROMOTED_PENDING_LOCAL_VISUAL_REVIEW`

## Next

`#FlagFix_109 — LABZ published local visual review after reference-layer promotion`

## Safety

No deploy.
No Netlify upload.
No push from published repo.
No build/pipeline.
No DeepL/translation.
No CSL changes.
No metadata CSV changes.
No TCC/SP10/SP11 changes.
No `.gitignore` changes.
No broad sync.
Production changes are documentation only.
