### PR TITLE
fix(flagfix): preserve LABZ state across theme toggle

### DIFF
--- a/docs/FlagFix/FLAGFIX_110_LABZ_DISAPPEARS_AFTER_THEME_TOGGLE.md
+++ b/docs/FlagFix/FLAGFIX_110_LABZ_DISAPPEARS_AFTER_THEME_TOGGLE.md
@@ -1,0 +1,54 @@
+# #FlagFix_110 — LABZ Disappears After Theme Toggle
+
+Date: 2026-05-19  
+Workspace: `/home/sanghop/axis/axis-niddhi-production`
+
+## Observed bug
+In local published review (`http://localhost:8088/archive.html`), LABZ flowers rendered initially, but disappeared after theme button interaction, and did not reliably return without refresh.
+
+## Root cause
+Runtime state conflict between normal theme controls and LABZ state:
+
+1. Theme buttons always wrote `data-theme` directly (light/dark/sunrise/colirio/sunset), which immediately exits `stardust` and hides LABZ ambient layer.
+2. LABZ used `axis-niddhi-theme` and `axis-theme-pre-labz` keys, while normal theme init used `br_theme`, creating state drift across toggles/reloads.
+3. LABZ state restore depended on mismatched storage assumptions, so behavior after theme interactions was inconsistent.
+
+## Files inspected
+- `pipeline/13-static-site/js/main.js`
+- `pipeline/13-static-site/css/style.css`
+- `pipeline/13-static-site/archive.html`
+- `pipeline/13-ssg/static/js/main.js`
+- `pipeline/13-ssg/static/css/style.css`
+- `pipeline/13-ssg/templates/base.html`
+
+## Patch applied
+Yes, minimal patch applied to JS source + static pair:
+- `pipeline/13-ssg/static/js/main.js`
+- `pipeline/13-static-site/js/main.js`
+
+No CSS/template/asset edits were needed.
+
+## Behavior change (before/after)
+Before:
+- Clicking theme button during LABZ could drop `stardust` rendering state and de-sync stored state.
+
+After:
+- If LABZ is active (`data-theme="stardust"`), clicking a theme button updates only the LABZ exit theme (`axis-theme-pre-labz`) and `br_theme`, without disabling LABZ immediately.
+- `initTheme()` now restores LABZ explicitly from `axis-niddhi-theme === "stardust"`.
+- Exiting LABZ synchronizes `br_theme` with restored non-LABZ theme.
+
+## Local validation steps
+1. Open `archive.html`.
+2. Activate LABZ.
+3. Click theme buttons while LABZ is active:
+   - LABZ visuals should remain active (stardust preserved).
+4. Exit LABZ:
+   - selected exit theme should apply cleanly.
+5. Reload page:
+   - LABZ/non-LABZ state should be consistent with stored values.
+
+## Published payload touched?
+No. `axis-niddhi-published` was not modified in this sprint.
+
+## Recommendation for #111
+`#FlagFix_111 — Published payload sync for LABZ theme-toggle runtime fix + local smoke check`

--- a/pipeline/13-ssg/static/js/main.js
+++ b/pipeline/13-ssg/static/js/main.js
@@ -40,11 +40,13 @@ function toggleLabz() {
   const isActive = document.body.getAttribute('data-theme') === 'stardust';
   const btn    = document.getElementById('labz-btn');
   const banner = document.getElementById('labz-banner');
+  const THEME_KEY = 'br_theme';
 
   if (isActive) {
     // Restaurar tema anterior
     const prev = localStorage.getItem('axis-theme-pre-labz') || 'dark';
     document.body.setAttribute('data-theme', prev);
+    localStorage.setItem(THEME_KEY, prev);
     localStorage.setItem('axis-niddhi-theme', prev);
     localStorage.removeItem('axis-theme-pre-labz');
     btn    && btn.classList.remove('labz-active');
@@ -78,13 +80,16 @@ function toggleLabz() {
 
   function initTheme() {
     const saved = localStorage.getItem(THEME_KEY);
-    if (saved) document.body.setAttribute('data-theme', saved);
-    // [FF-013] Restore labz button state if stardust was active
-    if (saved === 'stardust') {
+    const labzState = localStorage.getItem('axis-niddhi-theme');
+    if (labzState === 'stardust') {
+      document.body.setAttribute('data-theme', 'stardust');
+      // [FF-013] Restore labz button state if stardust was active
       const btn = document.getElementById('labz-btn');
       const banner = document.getElementById('labz-banner');
       btn    && btn.classList.add('labz-active');
       banner && banner.classList.add('visible');
+    } else if (saved) {
+      document.body.setAttribute('data-theme', saved);
     }
 
     const container = document.getElementById('theme-controls');
@@ -96,7 +101,14 @@ function toggleLabz() {
       b.className = 'theme-btn';
       b.textContent = t.icon;
       b.onclick = () => {
-        document.body.setAttribute('data-theme', t.id);
+        const isLabzActive = document.body.getAttribute('data-theme') === 'stardust';
+        if (isLabzActive) {
+          // Em LABZ, trocar tema ajusta o "tema de saída" sem desligar o stardust.
+          localStorage.setItem('axis-theme-pre-labz', t.id);
+        } else {
+          document.body.setAttribute('data-theme', t.id);
+          localStorage.setItem('axis-niddhi-theme', t.id);
+        }
         localStorage.setItem(THEME_KEY, t.id);
       };
       container.appendChild(b);

--- a/pipeline/13-static-site/js/main.js
+++ b/pipeline/13-static-site/js/main.js
@@ -40,11 +40,13 @@ function toggleLabz() {
   const isActive = document.body.getAttribute('data-theme') === 'stardust';
   const btn    = document.getElementById('labz-btn');
   const banner = document.getElementById('labz-banner');
+  const THEME_KEY = 'br_theme';
 
   if (isActive) {
     // Restaurar tema anterior
     const prev = localStorage.getItem('axis-theme-pre-labz') || 'dark';
     document.body.setAttribute('data-theme', prev);
+    localStorage.setItem(THEME_KEY, prev);
     localStorage.setItem('axis-niddhi-theme', prev);
     localStorage.removeItem('axis-theme-pre-labz');
     btn    && btn.classList.remove('labz-active');
@@ -78,13 +80,16 @@ function toggleLabz() {
 
   function initTheme() {
     const saved = localStorage.getItem(THEME_KEY);
-    if (saved) document.body.setAttribute('data-theme', saved);
+    const labzState = localStorage.getItem('axis-niddhi-theme');
+    if (labzState === 'stardust') {
+      document.body.setAttribute('data-theme', 'stardust');
     // [FF-013] Restore labz button state if stardust was active
-    if (saved === 'stardust') {
       const btn = document.getElementById('labz-btn');
       const banner = document.getElementById('labz-banner');
       btn    && btn.classList.add('labz-active');
       banner && banner.classList.add('visible');
+    } else if (saved) {
+      document.body.setAttribute('data-theme', saved);
     }
 
     const container = document.getElementById('theme-controls');
@@ -96,7 +101,14 @@ function toggleLabz() {
       b.className = 'theme-btn';
       b.textContent = t.icon;
       b.onclick = () => {
-        document.body.setAttribute('data-theme', t.id);
+        const isLabzActive = document.body.getAttribute('data-theme') === 'stardust';
+        if (isLabzActive) {
+          // Em LABZ, trocar tema ajusta o "tema de saída" sem desligar o stardust.
+          localStorage.setItem('axis-theme-pre-labz', t.id);
+        } else {
+          document.body.setAttribute('data-theme', t.id);
+          localStorage.setItem('axis-niddhi-theme', t.id);
+        }
         localStorage.setItem(THEME_KEY, t.id);
       };
       container.appendChild(b);


### PR DESCRIPTION
## Summary

Fixes #FlagFix_110: LABZ flowers disappeared after using the theme toggle.

## Root cause

Theme state conflict between `br_theme` and `axis-niddhi-theme`, with the theme click overwriting `data-theme` even while LABZ was active.

## Changes

JS-only patch:

- `pipeline/13-ssg/static/js/main.js`
- `pipeline/13-static-site/js/main.js`

Report:

- `docs/FlagFix/FLAGFIX_110_LABZ_DISAPPEARS_AFTER_THEME_TOGGLE.md`

## Validation

- `git diff --check`: passed
- `git diff --stat`: 2 JS files changed, 31 insertions, 7 deletions
- path scope: JS pair + report only

## Safety

No deploy.
No Netlify upload.
No build/pipeline.
No sync/copy to published.
No CSL/metadata/TCC/SP10/SP11/DeepL/translation changes.
No `.gitignore` changes.

## Next

#FlagFix_111 — Published payload sync for LABZ theme-toggle runtime fix + local smoke check
