### PR TITLE
docs(flagfix): close failed LABZ runtime quarantine

### DIFF
--- a/docs/FlagFix/FLAGFIX_111_PUBLISHED_LABZ_THEME_TOGGLE_SYNC_LOCAL_SMOKE.md
+++ b/docs/FlagFix/FLAGFIX_111_PUBLISHED_LABZ_THEME_TOGGLE_SYNC_LOCAL_SMOKE.md
@@ -1,0 +1,54 @@
+# #FlagFix_111 — Published payload sync for LABZ theme-toggle runtime fix + local smoke
+
+Date: 2026-05-19  
+Production: `/home/sanghop/axis/axis-niddhi-production`  
+Published: `/home/sanghop/axis/axis-niddhi-published`
+
+## Copied file
+- `/home/sanghop/axis/axis-niddhi-production/pipeline/13-static-site/js/main.js`
+  ->
+  `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site/js/main.js`
+
+## Diff counts
+- Before copy:
+  - `/tmp/flagfix_111_main_js_before.diff` = `51` lines
+- After copy:
+  - `/tmp/flagfix_111_main_js_after.diff` = `0` lines
+
+## Published path scope
+Current modified paths in published:
+- `pipeline/13-static-site/archive.html`
+- `pipeline/13-static-site/css/style.css`
+- `pipeline/13-static-site/js/main.js`
+
+Interpretation:
+- `js/main.js` is the intended #111 sync target.
+- `archive.html` and `css/style.css` are pre-existing pending changes from #108.
+- No unrelated additional paths were introduced by #111.
+
+## Local smoke checks (technical)
+Local server target:
+- `http://localhost:8088/archive.html`
+
+HTTP/status check:
+- `GET /archive.html` => `HTTP/1.0 200 OK`
+
+Runtime/markup prerequisites confirmed in served archive:
+- `.labz-ambient-layer` present
+- `#labz-btn` present
+- `toggleLabz()` button wiring present
+- `#theme-controls` present
+
+## Visual decision
+`PENDING_HUMAN_CONFIRMATION`
+
+Reason:
+- Technical/runtime prerequisites are in place.
+- Full interactive visual confirmation (theme toggle + flower persistence without hard refresh) requires direct human browser interaction.
+
+## Netlify/deploy status
+- Netlify upload: **No**
+- Deploy: **No**
+
+## Recommended #112
+`#FlagFix_112 — Human visual confirmation of LABZ theme-toggle persistence, then Netlify upload/public smoke if PASS`

--- a/docs/FlagFix/FLAGFIX_112_LABZ_THEME_BUTTON_REGRESSION_TRIAGE.md
+++ b/docs/FlagFix/FLAGFIX_112_LABZ_THEME_BUTTON_REGRESSION_TRIAGE.md
@@ -1,0 +1,67 @@
+# #FlagFix_112 — LABZ Theme Button Regression Triage
+
+Date: 2026-05-19  
+Workspace: `/home/sanghop/axis/axis-niddhi-production`
+
+## #111 human result
+FAIL — after #110, theme buttons appeared non-functional during LABZ usage.
+
+## Root cause
+#110 introduced a guard that prevented theme buttons from updating `data-theme` while LABZ (`stardust`) was active.
+
+Effect:
+- user clicked theme buttons but page theme did not change;
+- behavior looked like a dead theme switcher;
+- state handling also mixed `br_theme` and `axis-niddhi-theme` in a way that caused inconsistent expectations.
+
+## Diagnosis summary
+- Theme handling code and LABZ handling code live in:
+  - `pipeline/13-ssg/static/js/main.js`
+  - `pipeline/13-static-site/js/main.js`
+- Regression came from the `b.onclick` logic added in #110 that only updated `axis-theme-pre-labz` in LABZ mode, instead of switching theme.
+
+## Patch applied?
+Yes (minimal JS-only patch).
+
+## Changed files
+- `pipeline/13-ssg/static/js/main.js`
+- `pipeline/13-static-site/js/main.js`
+- `docs/FlagFix/FLAGFIX_112_LABZ_THEME_BUTTON_REGRESSION_TRIAGE.md`
+
+## Patch behavior
+1. Introduced small helper `setLabzUi(active)` for consistent LABZ button/banner UI state.
+2. `initTheme()` now computes effective theme from:
+   - `br_theme` (primary),
+   - fallback `axis-niddhi-theme` (legacy),
+   - fallback default `dark`.
+3. Theme button click now always updates:
+   - `data-theme`,
+   - `br_theme`,
+   - `axis-niddhi-theme`,
+   and refreshes LABZ UI state accordingly.
+4. When switching to non-stardust theme, stale `axis-theme-pre-labz` is cleared.
+
+## Validation results
+Commands run:
+- `git diff --check`
+- `git diff --stat`
+- `git diff --name-status`
+
+Result:
+- clean diff checks;
+- only expected JS files changed (plus this report).
+
+## Published touched?
+No. `axis-niddhi-published` was not modified in #112.
+
+## No-change confirmations
+- No deploy.
+- No Netlify upload.
+- No build/pipeline.
+- No broad sync/copy.
+- No CSL/metadata/TCC/SP10/SP11/DeepL/translation changes.
+- No `.gitignore` changes.
+- No LABZ image asset changes.
+
+## Recommended #113
+`#FlagFix_113 — Sync #112 JS runtime fix to published payload and run local human visual regression check`

--- a/docs/FlagFix/FLAGFIX_113_SYNC_LABZ_THEME_FIX_TO_PUBLISHED_LOCAL_REVIEW.md
+++ b/docs/FlagFix/FLAGFIX_113_SYNC_LABZ_THEME_FIX_TO_PUBLISHED_LOCAL_REVIEW.md
@@ -1,0 +1,51 @@
+# #FlagFix_113 — Sync LABZ Theme Fix To Published + Local Review
+
+Date: 2026-05-19  
+Production: `/home/sanghop/axis/axis-niddhi-production`  
+Published: `/home/sanghop/axis/axis-niddhi-published`
+
+## Copied path
+- From: `/home/sanghop/axis/axis-niddhi-production/pipeline/13-static-site/js/main.js`
+- To: `/home/sanghop/axis/axis-niddhi-published/pipeline/13-static-site/js/main.js`
+
+## Parity result
+- `/tmp/flagfix_113_main_js_parity.diff` line count: `0`
+- Result: production/published `main.js` parity confirmed.
+
+## Published path scope
+Published currently shows:
+- `pipeline/13-static-site/js/main.js` (intended #113 sync)
+- `pipeline/13-static-site/archive.html` (pre-existing pending from prior LABZ work)
+- `pipeline/13-static-site/css/style.css` (pre-existing pending from prior LABZ work)
+
+No broad sync paths were introduced by #113.
+
+## Local smoke status
+- Temporary local server on `8088` started successfully.
+- HTTP check: `GET /archive.html` returned `200 OK`.
+- Human visual status: `PENDING_HUMAN_CONFIRMATION`.
+
+Human test URL:
+- `http://localhost:8088/archive.html`
+
+Human checklist:
+1. Confirm flowers appear in LABZ.
+2. Click theme buttons and confirm they work.
+3. Confirm flowers do not disappear permanently after theme changes.
+4. Confirm no hard refresh (`Ctrl+Shift+R`) is needed.
+
+## Recommended #114
+- If human PASS:
+  - `#FlagFix_114 — LABZ Netlify upload and public smoke check after theme-toggle fix`
+- If human FAIL:
+  - `#FlagFix_114 — LABZ runtime regression round 2 (theme/LABZ state)`
+
+## No-change confirmations
+- No deploy.
+- No Netlify upload.
+- No push.
+- No build/pipeline.
+- No broad sync/copy.
+- No CSL/metadata/TCC/SP10/SP11/DeepL/translation changes.
+- No `.gitignore` changes.
+- No LABZ image asset changes.

--- a/docs/FlagFix/FLAGFIX_114_DEFER_LABZ_RUNTIME_THEME_POLISH.md
+++ b/docs/FlagFix/FLAGFIX_114_DEFER_LABZ_RUNTIME_THEME_POLISH.md
@@ -1,0 +1,55 @@
+# #FlagFix_114 — Defer LABZ Runtime/Theme Polish After Failed Local Review
+
+Date: 2026-05-19  
+Workspace: `/home/sanghop/axis`
+
+## Prior chain
+- `#107` confirmed LABZ rendering/reference gap in published.
+- `#108` promoted LABZ reference layer to published.
+- `#109` prepared local visual review.
+- `#110` patched LABZ disappearing after theme toggle.
+- `#111` synced JS runtime fix to published and requested visual confirmation.
+- `#112` patched regression where theme buttons stopped working.
+- `#113` synced #112 JS to published and prepared local review at `http://localhost:8088/archive.html`.
+
+## Human result
+`HUMAN_VISUAL_FAIL`
+
+Tested local URL:
+`http://localhost:8088/archive.html`
+
+Summary:
+LABZ/theme behavior remained unacceptable in local published review.
+
+## Final decision
+`LABZ_RUNTIME_THEME_POLISH_DEFERRED`
+
+- No further immediate FlagFixes for this LABZ runtime/theme behavior loop.
+- LABZ remains experimental/easter-egg infrastructure.
+- Future LABZ work should be handled as a new design/runtime redesign sprint, not emergency patching.
+
+## Deployment decision
+- No Netlify upload for this LABZ runtime/theme attempt.
+- No public promotion of this failed runtime fix cycle.
+- Vitrine remains acceptable without LABZ perfection.
+
+## Published repo note
+- `axis-niddhi-published` may still contain local pending LABZ-related edits from `#108/#111/#113`.
+- Do **not** clean/reset them in this sprint.
+- Any cleanup/reconciliation should be handled in a separate future maintenance sprint.
+
+## No-change confirmations
+- Documentation only.
+- No deploy.
+- No Netlify upload.
+- No push.
+- No build/pipeline.
+- No sync/copy.
+- No `axis-niddhi-published` modifications.
+- No website/CSS/JS/LABZ/Bodhi/flower edits.
+- No DeepL/translation.
+- No CSL/metadata/TCC/SP10/SP11 changes.
+- No `.gitignore` changes.
+
+## Next recommendation
+Pause LABZ runtime/theme patching. Re-open later only with a scoped redesign brief and explicit acceptance criteria.

--- a/docs/FlagFix/FLAGFIX_115_QUARANTINE_FAILED_LABZ_RUNTIME_PATCH_STATE.md
+++ b/docs/FlagFix/FLAGFIX_115_QUARANTINE_FAILED_LABZ_RUNTIME_PATCH_STATE.md
@@ -1,0 +1,50 @@
+# FLAGFIX_115 — Quarantine failed LABZ runtime patch state and restore production workspace cleanliness
+
+Date: 2026-05-19  
+Workspace: `/home/sanghop/axis/axis-niddhi-production`
+
+## Purpose
+
+Preserve evidence from the failed LABZ runtime/theme attempt while removing active failed JS runtime modifications from the production workspace.
+
+## Snapshot
+
+Snapshot path:
+
+`/home/sanghop/axis/labz-failed-runtime-snapshots/flagfix_115_labz_failed_runtime_20260519_210100`
+
+Snapshot includes:
+
+- `git_status_sb.txt`
+- `labz_runtime_js.diff`
+- copied reports (if present): `FLAGFIX_111`, `FLAGFIX_112`, `FLAGFIX_113`, `FLAGFIX_114`
+- `sha256_manifest.txt`
+
+## Restored JS paths
+
+The failed runtime JS changes were restored to current `HEAD` using `git restore`:
+
+- `pipeline/13-ssg/static/js/main.js`
+- `pipeline/13-static-site/js/main.js`
+
+## Decision continuity
+
+- #114 decision preserved: `LABZ_RUNTIME_THEME_POLISH_DEFERRED`
+- Failed JS runtime changes were not promoted.
+- LABZ runtime/theme polish remains deferred.
+
+## Non-actions confirmed
+
+- No deploy
+- No Netlify upload
+- No push
+- No build/pipeline run
+- No sync/copy to published
+- No modification to `axis-niddhi-published`
+- No changes to CSL/metadata/TCC/SP10/SP11
+- No DeepL/translation actions
+- No `.gitignore` changes
+
+## Forward recommendation
+
+Future LABZ runtime work should restart as a separate redesign/runtime sprint with explicit acceptance criteria and a clean validation gate before any promotion.


### PR DESCRIPTION
## Summary

Closes the failed LABZ runtime/theme-toggle experiment by preserving the documentation for #111–#115.

This records:

- the attempted LABZ theme-toggle sync/review path;
- the regression where theme buttons stopped working;
- the decision to defer LABZ runtime/theme polish;
- the quarantine snapshot of the failed runtime patch state;
- the restoration of runtime JS files back to clean main state.

## Files

Documentation only:

- `docs/FlagFix/FLAGFIX_111_PUBLISHED_LABZ_THEME_TOGGLE_SYNC_LOCAL_SMOKE.md`
- `docs/FlagFix/FLAGFIX_112_LABZ_THEME_BUTTON_REGRESSION_TRIAGE.md`
- `docs/FlagFix/FLAGFIX_113_SYNC_LABZ_THEME_FIX_TO_PUBLISHED_LOCAL_REVIEW.md`
- `docs/FlagFix/FLAGFIX_114_DEFER_LABZ_RUNTIME_THEME_POLISH.md`
- `docs/FlagFix/FLAGFIX_115_QUARANTINE_FAILED_LABZ_RUNTIME_PATCH_STATE.md`

## Safety

No runtime/code/site changes are included.
No Netlify upload.
No deploy.
No build/pipeline run.
No sync/copy.
No DeepL/translation.
No CSL/metadata/TCC/SP10/SP11 changes.
No `.gitignore` changes.

LABZ runtime/theme polish remains deferred for a future redesign sprint.
