### PR TITLE
Fix Lighthouse workflow trigger syntax

### DIFF
--- a/.github/workflows/lighthouse-deploy.yml
+++ b/.github/workflows/lighthouse-deploy.yml
@@ -1,9 +1,7 @@
 name: Deploy DhammaSeed para Lighthouse IPFS
 
 on:
-  push:
-    branches:
-      workflow_dispatch: # Run Workflow quando validações de deploy para Cloudfare estiverem aprovadas para Netlify
+  workflow_dispatch: # Run Workflow quando validações de deploy para Cloudfare estiverem aprovadas para Netlify
 
 jobs:
   deploy-to-ipfs:


### PR DESCRIPTION
Closes #206

## Summary

Fixes the Lighthouse deploy workflow trigger syntax by making workflow_dispatch a top-level manual trigger instead of nesting it under push.branches.

## Scope

- Changes only .github/workflows/lighthouse-deploy.yml.
- No deploy is run.
- No wrangler action.
- No Cloudflare settings change.
- No docs or audit notes added.

## Validation

- Workflow diff is limited to the trigger stanza.
- Staged diff check passed.
- Sanity check confirmed the malformed branches stanza is removed.