### PR TITLE
style: polish derived media companion block

### DIFF
--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -512,6 +512,61 @@ header .title-pt {
 /* ---------- DIGESTIBILITY (SPRINT 3) ---------- */
 .digestibility-suggestion { margin-top: 3rem; padding: 1.5rem; background-color: rgba(0,0,0,0.03); border-left: 4px solid var(--meta-color); border-radius: 4px; font-size: 0.95rem; color: var(--meta-color); }
 
+/* ---------- DERIVED MEDIA COMPANION (UX POLISH) ----------
+   Deliberately neutral (meta-color / border-color, not --green-axiom):
+   this block is auxiliary derived material, not canonical text,
+   and should read as quieter than the CSL content around it. */
+.derived-media-companion {
+  margin-top: 3rem;
+  padding: 1.4rem 1.6rem;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: rgba(128, 128, 128, 0.035);
+}
+.derived-media-kicker {
+  margin: 0 0 0.6rem;
+  font-family: Georgia, serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--meta-color);
+}
+.derived-media-note {
+  margin: 0 0 1.1rem;
+  font-size: 0.88rem;
+  font-style: italic;
+  line-height: 1.6;
+  color: var(--meta-color);
+}
+.derived-media-summary summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.85rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  font-size: 0.82rem;
+  color: var(--meta-color);
+  cursor: pointer;
+  list-style: none;
+  transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+}
+.derived-media-summary summary::-webkit-details-marker { display: none; }
+.derived-media-summary summary::before { content: "▸"; font-size: 0.7rem; transition: transform 0.2s ease; }
+.derived-media-summary[open] summary::before { transform: rotate(90deg); }
+.derived-media-summary summary:hover { border-color: var(--meta-color); background: rgba(128, 128, 128, 0.08); }
+.derived-media-summary summary:focus-visible { outline: 2px solid rgba(0, 204, 0, 0.35); outline-offset: 2px; }
+.derived-media-summary[open] summary { margin-bottom: 1rem; }
+.derived-media-summary-body { font-size: 0.95rem; line-height: 1.75; }
+.derived-media-summary-body p { margin: 0 0 1rem; }
+.derived-media-summary-body p:last-child { margin-bottom: 0; }
+.derived-media-raw-link { margin: 1rem 0 0; font-size: 0.78rem; }
+.derived-media-raw-link a { color: var(--meta-color); text-decoration: none; border-bottom: 1px dotted var(--meta-color); }
+.derived-media-raw-link a:hover { color: var(--fg); border-bottom-color: var(--fg); }
+.derived-media-audio, .derived-media-video { margin-top: 1rem; }
+.derived-media-external { margin: 1rem 0 0; padding-left: 1.2rem; font-size: 0.85rem; color: var(--meta-color); }
+
 /* ---------- FUTURE HOOKS (SPRINT 4) ---------- */
 #reading-progress-hook, #ai-assistant-hook { display: none; width: 100%; }
 
@@ -786,7 +841,7 @@ footer { margin-top: 4.5rem; font-size: 0.85rem; opacity: 0.65; text-align: cent
   /* [FLAGFIX-017] Hide screen reading progress bar in printed/PDF copies. */
   #reading-progress,
   #reading-progress-hook, #ai-assistant-hook,
-  .digestibility-suggestion, .silent-pause-block,
+  .digestibility-suggestion, .silent-pause-block, .derived-media-companion,
   #search-form, #search-results, #print-modal, #print-modal-overlay, #labz-banner,
   .labz-ambient-layer,
   iframe, .youtube-wrapper, .video-container { display: none !important; }

--- a/pipeline/13-ssg/templates/post.html
+++ b/pipeline/13-ssg/templates/post.html
@@ -119,8 +119,8 @@
              aria-labelledby="derived-media-title-{{ post.pdpn }}"
              data-source-pdpn="{{ derived_media.source_pdpn }}"
              data-review-status="{{ derived_media.review_status }}">
-        <h2 id="derived-media-title-{{ post.pdpn }}">{{ derived_media_labels.heading or 'Auxiliary derived media' }}</h2>
-        <p>{{ derived_media_labels.note or 'This NotebookLM-generated companion material is auxiliary. The CSL remains the source of truth.' }}</p>
+        <h2 id="derived-media-title-{{ post.pdpn }}" class="derived-media-kicker">{{ derived_media_labels.heading or 'Auxiliary derived media' }}</h2>
+        <p class="derived-media-note">{{ derived_media_labels.note or 'This NotebookLM-generated companion material is auxiliary. The CSL remains the source of truth.' }}</p>
 
         {% if derived_media.summary and derived_media.summary.path %}
         {% if derived_media.summary.html %}
@@ -131,27 +131,27 @@
             </div>
         </details>
         {% endif %}
-        <p>
+        <p class="derived-media-raw-link">
             <a href="{{ relative_root }}{{ derived_media.summary.path }}">{{ derived_media_labels.raw_summary_label or 'Open Markdown summary' }}</a>
         </p>
         {% endif %}
 
         {% if derived_media.audio and derived_media.audio.url %}
-        <div>
+        <div class="derived-media-audio">
             <p>Auxiliary audio</p>
             <audio controls preload="metadata" src="{{ derived_media.audio.url }}"></audio>
         </div>
         {% endif %}
 
         {% if derived_media.video and derived_media.video.url %}
-        <div>
+        <div class="derived-media-video">
             <p>Auxiliary video</p>
             <video controls preload="metadata" src="{{ derived_media.video.url }}"></video>
         </div>
         {% endif %}
 
         {% if derived_media.external %}
-        <ul>
+        <ul class="derived-media-external">
             {% if derived_media.external.telegram %}
             <li><a href="{{ derived_media.external.telegram }}" target="_blank" rel="noopener noreferrer">Auxiliary Telegram link</a></li>
             {% endif %}

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -512,6 +512,61 @@ header .title-pt {
 /* ---------- DIGESTIBILITY (SPRINT 3) ---------- */
 .digestibility-suggestion { margin-top: 3rem; padding: 1.5rem; background-color: rgba(0,0,0,0.03); border-left: 4px solid var(--meta-color); border-radius: 4px; font-size: 0.95rem; color: var(--meta-color); }
 
+/* ---------- DERIVED MEDIA COMPANION (UX POLISH) ----------
+   Deliberately neutral (meta-color / border-color, not --green-axiom):
+   this block is auxiliary derived material, not canonical text,
+   and should read as quieter than the CSL content around it. */
+.derived-media-companion {
+  margin-top: 3rem;
+  padding: 1.4rem 1.6rem;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: rgba(128, 128, 128, 0.035);
+}
+.derived-media-kicker {
+  margin: 0 0 0.6rem;
+  font-family: Georgia, serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--meta-color);
+}
+.derived-media-note {
+  margin: 0 0 1.1rem;
+  font-size: 0.88rem;
+  font-style: italic;
+  line-height: 1.6;
+  color: var(--meta-color);
+}
+.derived-media-summary summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.85rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  font-size: 0.82rem;
+  color: var(--meta-color);
+  cursor: pointer;
+  list-style: none;
+  transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+}
+.derived-media-summary summary::-webkit-details-marker { display: none; }
+.derived-media-summary summary::before { content: "▸"; font-size: 0.7rem; transition: transform 0.2s ease; }
+.derived-media-summary[open] summary::before { transform: rotate(90deg); }
+.derived-media-summary summary:hover { border-color: var(--meta-color); background: rgba(128, 128, 128, 0.08); }
+.derived-media-summary summary:focus-visible { outline: 2px solid rgba(0, 204, 0, 0.35); outline-offset: 2px; }
+.derived-media-summary[open] summary { margin-bottom: 1rem; }
+.derived-media-summary-body { font-size: 0.95rem; line-height: 1.75; }
+.derived-media-summary-body p { margin: 0 0 1rem; }
+.derived-media-summary-body p:last-child { margin-bottom: 0; }
+.derived-media-raw-link { margin: 1rem 0 0; font-size: 0.78rem; }
+.derived-media-raw-link a { color: var(--meta-color); text-decoration: none; border-bottom: 1px dotted var(--meta-color); }
+.derived-media-raw-link a:hover { color: var(--fg); border-bottom-color: var(--fg); }
+.derived-media-audio, .derived-media-video { margin-top: 1rem; }
+.derived-media-external { margin: 1rem 0 0; padding-left: 1.2rem; font-size: 0.85rem; color: var(--meta-color); }
+
 /* ---------- FUTURE HOOKS (SPRINT 4) ---------- */
 #reading-progress-hook, #ai-assistant-hook { display: none; width: 100%; }
 
@@ -786,7 +841,7 @@ footer { margin-top: 4.5rem; font-size: 0.85rem; opacity: 0.65; text-align: cent
   /* [FLAGFIX-017] Hide screen reading progress bar in printed/PDF copies. */
   #reading-progress,
   #reading-progress-hook, #ai-assistant-hook,
-  .digestibility-suggestion, .silent-pause-block,
+  .digestibility-suggestion, .silent-pause-block, .derived-media-companion,
   #search-form, #search-results, #print-modal, #print-modal-overlay, #labz-banner,
   .labz-ambient-layer,
   iframe, .youtube-wrapper, .video-container { display: none !important; }

--- a/pipeline/13-static-site/pages/TL.BB.002/index.html
+++ b/pipeline/13-static-site/pages/TL.BB.002/index.html
@@ -229,15 +229,20 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 </ul>
 <p>A seguir, “<a href="../../pages/TL.BB.003/index.html" target="_blank">A Lei da Atração, Hábitos, Caráter (Gati) e Desejos (Āsavas)</a>”, ...........</p>
     </article>
+    
 
-
+    
+    
+    
     <section class="derived-media-companion"
              aria-labelledby="derived-media-title-TL.BB.002"
              data-source-pdpn="TL.BB.002"
              data-review-status="approved">
-        <h2 id="derived-media-title-TL.BB.002">Material auxiliar derivado</h2>
-        <p>Este material complementar gerado pelo NotebookLM é auxiliar. A CSL continua sendo a fonte de verdade.</p>
+        <h2 id="derived-media-title-TL.BB.002" class="derived-media-kicker">Material auxiliar derivado</h2>
+        <p class="derived-media-note">Este material complementar gerado pelo NotebookLM é auxiliar. A CSL continua sendo a fonte de verdade.</p>
 
+        
+        
         <details class="derived-media-summary" aria-label="Resumo auxiliar">
             <summary>Ler resumo auxiliar</summary>
             <div class="derived-media-summary-body">
@@ -247,13 +252,19 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 <p>Use este resumo apenas como convite de orientação. Para estudo, retorne ao ensaio completo.</p>
             </div>
         </details>
-        <p>
+        
+        <p class="derived-media-raw-link">
             <a href="../../derived_media/summaries/TL.BB.002.pt-BR.md">Abrir resumo em Markdown</a>
         </p>
+        
 
+        
 
+        
 
+        
     </section>
+    
 
     <!-- SPRINT 3: Digestibility Suggestion -->
     


### PR DESCRIPTION
## Summary
- Restyles the Derived Media Companion block (`TL.BB.002`) as a quiet, neutral card — border + `--meta-color`, deliberately *not* the site's canonical `--green-axiom` accent, so it visually reads as auxiliary rather than canonical.
- pt-BR heading ("Material auxiliar derivado") becomes a small uppercase kicker label instead of a full-size `<h2>`.
- The "A CSL continua sendo a fonte de verdade." note is softened to a gentle italic line.
- The `<details>` summary toggle is restyled as a pill button matching existing site controls (TOC reveal, post-info toggle).
- The raw Markdown link is demoted to a small, discreet secondary action.
- Block is hidden from print output, consistent with other auxiliary blocks (`digestibility-suggestion`, `silent-pause-block`).
- CSS classes also added to the (currently empty) audio/video/external-link branches so future derived-media entries inherit consistent styling without further template work.

No labels, manifest, registry, or summary content were touched — only presentation (template markup classes + CSS). The pt-BR label text itself is generated in `pipeline/13-ssg/src/renderers/post_renderer.py` (untouched) and was already correct.

## Test plan
- [x] Ran `pipeline/13-ssg/build.py` and manually restored the surgical diff so only `pages/TL.BB.002/index.html` + `css/style.css` were regenerated (a full rebuild surfaced unrelated pre-existing drift on ~750 other pages — reverted, not part of this PR)
- [x] Served the static site locally and took a headless-Chromium screenshot of the rendered `TL.BB.002` page to confirm the card, kicker label, note, pill-styled summary toggle, and secondary Markdown link all render correctly
- [x] Confirmed Portuguese labels are preserved and inline summary still renders inside `<details>`
- [x] Confirmed no audio/video players render (no such data in the manifest for this sample)
- [x] Confirmed diff scope is limited to 2 template/CSS source files + the 1 regenerated output page (no neighbor pages, no CSL/translations/manifest/registry files touched, no binary media)

🤖 Generated with [Claude Code](https://claude.com/claude-code)