### PR TITLE
Gate Derived Media by active language

### DIFF
--- a/pipeline/13-ssg/src/renderers/post_renderer.py
+++ b/pipeline/13-ssg/src/renderers/post_renderer.py
@@ -177,6 +177,7 @@ def _prepare_derived_media_for_template(
         summary_path = str(summary.get("path", ""))
 
     language = _detect_derived_summary_language(summary_path, post)
+    prepared["media_language"] = language
     prepared["labels"] = dict(_DERIVED_MEDIA_LABELS.get(language, _DERIVED_MEDIA_LABELS["en-US"]))
     return prepared
 

--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -414,7 +414,8 @@ a:hover { color: var(--green-axiom); text-decoration: underline; }
 /* Visibility Logic */
 .content-en, .content-pt, .title-en, .title-pt,
 .current-crumb-en, .current-crumb-pt, .toc-en, .toc-pt,
-.meta-toggle-label-en, .meta-toggle-label-pt { display: none; }
+.meta-toggle-label-en, .meta-toggle-label-pt,
+.derived-media-language-en, .derived-media-language-pt { display: none; }
 
 #lang-en:checked ~ header .title-en,
 #lang-en:checked ~ .post-container .content-en,
@@ -425,6 +426,7 @@ a:hover { color: var(--green-axiom); text-decoration: underline; }
 #lang-en:checked ~ .post-container .content-en { display: block; }
 #lang-en:checked ~ .post-container .toc-en { display: block; }
 #lang-en:checked ~ .post-container .breadcrumbs .current-crumb-en { display: inline-block; }
+#lang-en:checked ~ .post-container .derived-media-language-en { display: block; }
 
 #lang-pt:checked ~ header .title-pt,
 #lang-pt:checked ~ .post-container .content-pt,
@@ -435,6 +437,7 @@ a:hover { color: var(--green-axiom); text-decoration: underline; }
 #lang-pt:checked ~ .post-container .content-pt { display: block; }
 #lang-pt:checked ~ .post-container .toc-pt { display: block; }
 #lang-pt:checked ~ .post-container .breadcrumbs .current-crumb-pt { display: inline-block; }
+#lang-pt:checked ~ .post-container .derived-media-language-pt { display: block; }
 
 /* Keep active post titles block-level; language label spans remain inline. */
 #lang-en:checked ~ header .title-en,
@@ -564,6 +567,8 @@ header .title-pt {
 .derived-media-raw-link { margin: 1rem 0 0; font-size: 0.78rem; }
 .derived-media-raw-link a { color: var(--meta-color); text-decoration: none; border-bottom: 1px dotted var(--meta-color); }
 .derived-media-raw-link a:hover { color: var(--fg); border-bottom-color: var(--fg); }
+.derived-media-preparation-notice { padding: 1rem 1.2rem; }
+.derived-media-preparation-notice .derived-media-note { margin-bottom: 0; }
 .derived-media-audio, .derived-media-video { margin-top: 1rem; max-width: 100%; overflow: hidden; }
 .derived-media-companion audio { max-width: 100%; }
 .derived-media-companion video {

--- a/pipeline/13-ssg/templates/post.html
+++ b/pipeline/13-ssg/templates/post.html
@@ -115,10 +115,23 @@
     %}
     {% if has_derived_media_links %}
     {% set derived_media_labels = derived_media.labels or {} %}
-    <section class="derived-media-companion"
+    {% set derived_media_media_language = derived_media.media_language or 'en-US' %}
+    {% set derived_media_language_class = 'derived-media-language-pt' if derived_media_media_language == 'pt-BR' else 'derived-media-language-en' %}
+    {% if derived_media_media_language == 'pt-BR' %}
+    <section class="derived-media-companion derived-media-preparation-notice derived-media-language-en"
+             aria-labelledby="derived-media-notice-title-{{ post.pdpn }}"
+             data-source-pdpn="{{ derived_media.source_pdpn }}"
+             data-review-status="{{ derived_media.review_status }}"
+             data-companion-language="en-US">
+        <h2 id="derived-media-notice-title-{{ post.pdpn }}" class="derived-media-kicker">Auxiliary derived media</h2>
+        <p class="derived-media-note">Companion audio/video in English is being prepared. The Portuguese companion is available under the Português tab.</p>
+    </section>
+    {% endif %}
+    <section class="derived-media-companion {{ derived_media_language_class }}"
              aria-labelledby="derived-media-title-{{ post.pdpn }}"
              data-source-pdpn="{{ derived_media.source_pdpn }}"
-             data-review-status="{{ derived_media.review_status }}">
+             data-review-status="{{ derived_media.review_status }}"
+             data-companion-language="{{ derived_media_media_language }}">
         <h2 id="derived-media-title-{{ post.pdpn }}" class="derived-media-kicker">{{ derived_media_labels.heading or 'Auxiliary derived media' }}</h2>
         <p class="derived-media-note">{{ derived_media_labels.note or 'This NotebookLM-generated companion material is auxiliary. The CSL remains the source of truth.' }}</p>
 

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -414,7 +414,8 @@ a:hover { color: var(--green-axiom); text-decoration: underline; }
 /* Visibility Logic */
 .content-en, .content-pt, .title-en, .title-pt,
 .current-crumb-en, .current-crumb-pt, .toc-en, .toc-pt,
-.meta-toggle-label-en, .meta-toggle-label-pt { display: none; }
+.meta-toggle-label-en, .meta-toggle-label-pt,
+.derived-media-language-en, .derived-media-language-pt { display: none; }
 
 #lang-en:checked ~ header .title-en,
 #lang-en:checked ~ .post-container .content-en,
@@ -425,6 +426,7 @@ a:hover { color: var(--green-axiom); text-decoration: underline; }
 #lang-en:checked ~ .post-container .content-en { display: block; }
 #lang-en:checked ~ .post-container .toc-en { display: block; }
 #lang-en:checked ~ .post-container .breadcrumbs .current-crumb-en { display: inline-block; }
+#lang-en:checked ~ .post-container .derived-media-language-en { display: block; }
 
 #lang-pt:checked ~ header .title-pt,
 #lang-pt:checked ~ .post-container .content-pt,
@@ -435,6 +437,7 @@ a:hover { color: var(--green-axiom); text-decoration: underline; }
 #lang-pt:checked ~ .post-container .content-pt { display: block; }
 #lang-pt:checked ~ .post-container .toc-pt { display: block; }
 #lang-pt:checked ~ .post-container .breadcrumbs .current-crumb-pt { display: inline-block; }
+#lang-pt:checked ~ .post-container .derived-media-language-pt { display: block; }
 
 /* Keep active post titles block-level; language label spans remain inline. */
 #lang-en:checked ~ header .title-en,
@@ -564,6 +567,8 @@ header .title-pt {
 .derived-media-raw-link { margin: 1rem 0 0; font-size: 0.78rem; }
 .derived-media-raw-link a { color: var(--meta-color); text-decoration: none; border-bottom: 1px dotted var(--meta-color); }
 .derived-media-raw-link a:hover { color: var(--fg); border-bottom-color: var(--fg); }
+.derived-media-preparation-notice { padding: 1rem 1.2rem; }
+.derived-media-preparation-notice .derived-media-note { margin-bottom: 0; }
 .derived-media-audio, .derived-media-video { margin-top: 1rem; max-width: 100%; overflow: hidden; }
 .derived-media-companion audio { max-width: 100%; }
 .derived-media-companion video {

--- a/pipeline/13-static-site/pages/TL.BB.002/index.html
+++ b/pipeline/13-static-site/pages/TL.BB.002/index.html
@@ -69,7 +69,7 @@
           Features experimentais ativas &nbsp;·&nbsp;
           <button onclick="toggleLabz()" style="background:none;border:none;cursor:pointer;color:inherit;font:inherit;text-decoration:underline;padding:0;">sair do modo Labz</button>
         </div>
-        
+
 
 <!-- reading-progress-hook removed FF-016: #reading-progress now in base.html -->
 
@@ -229,20 +229,33 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 </ul>
 <p>A seguir, “<a href="../../pages/TL.BB.003/index.html" target="_blank">A Lei da Atração, Hábitos, Caráter (Gati) e Desejos (Āsavas)</a>”, ...........</p>
     </article>
-    
 
-    
-    
-    
-    <section class="derived-media-companion"
+
+
+
+
+
+
+
+    <section class="derived-media-companion derived-media-preparation-notice derived-media-language-en"
+             aria-labelledby="derived-media-notice-title-TL.BB.002"
+             data-source-pdpn="TL.BB.002"
+             data-review-status="approved"
+             data-companion-language="en-US">
+        <h2 id="derived-media-notice-title-TL.BB.002" class="derived-media-kicker">Auxiliary derived media</h2>
+        <p class="derived-media-note">Companion audio/video in English is being prepared. The Portuguese companion is available under the Português tab.</p>
+    </section>
+
+    <section class="derived-media-companion derived-media-language-pt"
              aria-labelledby="derived-media-title-TL.BB.002"
              data-source-pdpn="TL.BB.002"
-             data-review-status="approved">
+             data-review-status="approved"
+             data-companion-language="pt-BR">
         <h2 id="derived-media-title-TL.BB.002" class="derived-media-kicker">Material auxiliar derivado</h2>
         <p class="derived-media-note">Este material complementar gerado pelo NotebookLM é auxiliar. A CSL continua sendo a fonte de verdade.</p>
 
-        
-        
+
+
         <details class="derived-media-summary" aria-label="Resumo auxiliar">
             <summary>Ler resumo auxiliar</summary>
             <div class="derived-media-summary-body">
@@ -252,7 +265,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 <p>Use este resumo apenas como convite de orientação. Para estudo, retorne ao ensaio completo.</p>
             </div>
         </details>
-        
+
         <p class="derived-media-raw-link">
             <a href="../../derived_media/summaries/TL.BB.002.pt-BR.md">Abrir resumo em Markdown</a>
         </p>
@@ -272,9 +285,8 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
         </div>
 
 
-
     </section>
-    
+
 
     <!-- SPRINT 3: Digestibility Suggestion -->
     


### PR DESCRIPTION
## Summary

Ensures the pt-BR Derived Media companion for `TL.BB.002` only appears when Portuguese is active, while the English state shows a preparation notice.

## Scope

- Language-aware Derived Media visibility.
- No media binary files.
- No R2 URL changes.
- No registry/manifest changes unless required by implementation.
- No Canon/CSL/source changes.
- No Netlify promotion.

## Validation

- Static build passed.
- TL.BB.002 English state shows preparation notice.
- TL.BB.002 Portuguese state shows summary/audio/video.
- Neighbor pages unaffected.
- No binary media tracked.
- Cloudflare preview checked.

## Rollback

Revert this commit to restore previous Derived Media rendering behavior.
