### PR TITLE
Polish audio video Derived Media Companion UX

### DIFF
--- a/pipeline/13-ssg/src/renderers/post_renderer.py
+++ b/pipeline/13-ssg/src/renderers/post_renderer.py
@@ -134,21 +134,25 @@ def _classify_level(section_code: str) -> str:
 _DERIVED_MEDIA_LABELS = {
     "pt-BR": {
         "heading": "Material auxiliar",
-        "note": "Este áudio e vídeo são materiais auxiliares de estudo preparados com apoio do NotebookLM a partir do ensaio original do PureDhamma.net. Eles não substituem o texto original em inglês, que continua sendo a referência principal para estudo e verificação. Atenção: o NotebookLM pode cometer erros de pronúncia ou reconhecimento de termos em Pāli e Sinhala/Cingalês, inclusive confundindo palavras com formas em Sânscrito.",
+        "note": "Este áudio e vídeo são materiais auxiliares de estudo preparados com apoio do NotebookLM a partir do ensaio original do PureDhamma.net.",
+        "reference": "Eles não substituem o texto original em inglês, que continua sendo a referência principal para estudo e verificação.",
+        "warning": "Atenção: o NotebookLM pode cometer erros de pronúncia ou reconhecimento de termos em Pāli e Sinhala/Cingalês, inclusive confundindo palavras com formas em Sânscrito.",
         "summary_label": "Resumo auxiliar",
         "summary_details_label": "Ler resumo auxiliar",
         "raw_summary_label": "Abrir resumo em Markdown",
-        "audio_label": "Áudio auxiliar",
-        "video_label": "Vídeo auxiliar",
+        "audio_label": "Áudio do ensaio",
+        "video_label": "Vídeo do ensaio",
     },
     "en-US": {
         "heading": "Auxiliary media",
-        "note": "This audio and video are auxiliary study materials prepared with NotebookLM from the original PureDhamma.net essay. They do not replace the original English text, which remains the main reference for study and verification. NotebookLM may mispronounce or misrecognize Pāli and Sinhala terms, including possible confusion with Sanskrit forms.",
+        "note": "This audio and video are auxiliary study materials prepared with NotebookLM from the original PureDhamma.net essay.",
+        "reference": "They do not replace the original English text, which remains the main reference for study and verification.",
+        "warning": "Note: NotebookLM may mispronounce or misrecognize Pāli and Sinhala terms, including possible confusion with Sanskrit forms.",
         "summary_label": "Auxiliary summary",
         "summary_details_label": "Read auxiliary summary",
         "raw_summary_label": "Open Markdown summary",
-        "audio_label": "Auxiliary audio",
-        "video_label": "Auxiliary video",
+        "audio_label": "Essay audio",
+        "video_label": "Essay video",
     },
 }
 

--- a/pipeline/13-ssg/static/css/style.css
+++ b/pipeline/13-ssg/static/css/style.css
@@ -535,11 +535,30 @@ header .title-pt {
   letter-spacing: 0.07em;
   color: var(--meta-color);
 }
+.derived-media-copy { margin: 0 0 1.1rem; }
+.derived-media-copy > *:last-child { margin-bottom: 0; }
 .derived-media-note {
-  margin: 0 0 1.1rem;
+  margin: 0 0 0.75rem;
   font-size: 0.88rem;
   font-style: italic;
   line-height: 1.6;
+  color: var(--meta-color);
+}
+.derived-media-reference {
+  margin: 0 0 0.9rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--meta-color);
+  opacity: 0.85;
+}
+.derived-media-warning {
+  margin: 0;
+  padding: 0.55rem 0.9rem;
+  border-left: 2px solid var(--border-color);
+  border-radius: 0 6px 6px 0;
+  background: rgba(128, 128, 128, 0.05);
+  font-size: 0.8rem;
+  line-height: 1.55;
   color: var(--meta-color);
 }
 .derived-media-summary summary {
@@ -569,14 +588,37 @@ header .title-pt {
 .derived-media-raw-link a:hover { color: var(--fg); border-bottom-color: var(--fg); }
 .derived-media-preparation-notice { padding: 1rem 1.2rem; }
 .derived-media-preparation-notice .derived-media-note { margin-bottom: 0; }
-.derived-media-audio, .derived-media-video { margin-top: 1rem; max-width: 100%; overflow: hidden; }
-.derived-media-companion audio { max-width: 100%; }
+.derived-media-player-group {
+  margin-top: 1.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+.derived-media-audio, .derived-media-video { max-width: 100%; }
+.derived-media-player-label {
+  margin: 0 0 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--meta-color);
+}
+.derived-media-player-shell {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-paper);
+  padding: 0.6rem;
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+.derived-media-player-shell:focus-within { border-color: var(--meta-color); }
+.derived-media-companion audio { display: block; width: 100%; max-width: 100%; }
 .derived-media-companion video {
   display: block;
   width: 100%;
   max-width: 100%;
   height: auto;
   box-sizing: border-box;
+  border-radius: 4px;
 }
 .derived-media-external { margin: 1rem 0 0; padding-left: 1.2rem; font-size: 0.85rem; color: var(--meta-color); }
 

--- a/pipeline/13-ssg/templates/post.html
+++ b/pipeline/13-ssg/templates/post.html
@@ -133,7 +133,15 @@
              data-review-status="{{ derived_media.review_status }}"
              data-companion-language="{{ derived_media_media_language }}">
         <h2 id="derived-media-title-{{ post.pdpn }}" class="derived-media-kicker">{{ derived_media_labels.heading or 'Auxiliary derived media' }}</h2>
-        <p class="derived-media-note">{{ derived_media_labels.note or 'This audio and video are auxiliary study materials prepared with NotebookLM from the original PureDhamma.net essay. They do not replace the original English text, which remains the main reference for study and verification.' }}</p>
+        <div class="derived-media-copy">
+            <p class="derived-media-note">{{ derived_media_labels.note or 'This audio and video are auxiliary study materials prepared with NotebookLM from the original PureDhamma.net essay.' }}</p>
+            {% if derived_media_labels.reference %}
+            <p class="derived-media-reference">{{ derived_media_labels.reference }}</p>
+            {% endif %}
+            {% if derived_media_labels.warning %}
+            <p class="derived-media-warning">{{ derived_media_labels.warning }}</p>
+            {% endif %}
+        </div>
 
         {% if derived_media.summary and derived_media.summary.path %}
         {% if derived_media.summary.html %}
@@ -149,17 +157,25 @@
         </p>
         {% endif %}
 
-        {% if derived_media.audio and derived_media.audio.url %}
-        <div class="derived-media-audio">
-            <p>{{ derived_media_labels.audio_label or 'Auxiliary audio' }}</p>
-            <audio controls preload="metadata" src="{{ derived_media.audio.url }}"></audio>
-        </div>
-        {% endif %}
+        {% if (derived_media.audio and derived_media.audio.url) or (derived_media.video and derived_media.video.url) %}
+        <div class="derived-media-player-group">
+            {% if derived_media.audio and derived_media.audio.url %}
+            <div class="derived-media-audio">
+                <p id="derived-media-audio-label-{{ post.pdpn }}" class="derived-media-player-label">{{ derived_media_labels.audio_label or 'Auxiliary audio' }}</p>
+                <div class="derived-media-player-shell">
+                    <audio controls preload="metadata" src="{{ derived_media.audio.url }}" aria-labelledby="derived-media-audio-label-{{ post.pdpn }}"></audio>
+                </div>
+            </div>
+            {% endif %}
 
-        {% if derived_media.video and derived_media.video.url %}
-        <div class="derived-media-video">
-            <p>{{ derived_media_labels.video_label or 'Auxiliary video' }}</p>
-            <video controls preload="metadata" src="{{ derived_media.video.url }}"></video>
+            {% if derived_media.video and derived_media.video.url %}
+            <div class="derived-media-video">
+                <p id="derived-media-video-label-{{ post.pdpn }}" class="derived-media-player-label">{{ derived_media_labels.video_label or 'Auxiliary video' }}</p>
+                <div class="derived-media-player-shell">
+                    <video controls preload="metadata" src="{{ derived_media.video.url }}" aria-labelledby="derived-media-video-label-{{ post.pdpn }}"></video>
+                </div>
+            </div>
+            {% endif %}
         </div>
         {% endif %}
 

--- a/pipeline/13-static-site/css/style.css
+++ b/pipeline/13-static-site/css/style.css
@@ -535,11 +535,30 @@ header .title-pt {
   letter-spacing: 0.07em;
   color: var(--meta-color);
 }
+.derived-media-copy { margin: 0 0 1.1rem; }
+.derived-media-copy > *:last-child { margin-bottom: 0; }
 .derived-media-note {
-  margin: 0 0 1.1rem;
+  margin: 0 0 0.75rem;
   font-size: 0.88rem;
   font-style: italic;
   line-height: 1.6;
+  color: var(--meta-color);
+}
+.derived-media-reference {
+  margin: 0 0 0.9rem;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  color: var(--meta-color);
+  opacity: 0.85;
+}
+.derived-media-warning {
+  margin: 0;
+  padding: 0.55rem 0.9rem;
+  border-left: 2px solid var(--border-color);
+  border-radius: 0 6px 6px 0;
+  background: rgba(128, 128, 128, 0.05);
+  font-size: 0.8rem;
+  line-height: 1.55;
   color: var(--meta-color);
 }
 .derived-media-summary summary {
@@ -569,14 +588,37 @@ header .title-pt {
 .derived-media-raw-link a:hover { color: var(--fg); border-bottom-color: var(--fg); }
 .derived-media-preparation-notice { padding: 1rem 1.2rem; }
 .derived-media-preparation-notice .derived-media-note { margin-bottom: 0; }
-.derived-media-audio, .derived-media-video { margin-top: 1rem; max-width: 100%; overflow: hidden; }
-.derived-media-companion audio { max-width: 100%; }
+.derived-media-player-group {
+  margin-top: 1.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+.derived-media-audio, .derived-media-video { max-width: 100%; }
+.derived-media-player-label {
+  margin: 0 0 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--meta-color);
+}
+.derived-media-player-shell {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-paper);
+  padding: 0.6rem;
+  overflow: hidden;
+  transition: border-color 0.2s ease;
+}
+.derived-media-player-shell:focus-within { border-color: var(--meta-color); }
+.derived-media-companion audio { display: block; width: 100%; max-width: 100%; }
 .derived-media-companion video {
   display: block;
   width: 100%;
   max-width: 100%;
   height: auto;
   box-sizing: border-box;
+  border-radius: 4px;
 }
 .derived-media-external { margin: 1rem 0 0; padding-left: 1.2rem; font-size: 0.85rem; color: var(--meta-color); }
 

--- a/pipeline/13-static-site/pages/TL.BB.002/index.html
+++ b/pipeline/13-static-site/pages/TL.BB.002/index.html
@@ -53,7 +53,7 @@
     <main>
         <!-- Search UI (Sprint 9) -->
         <form id="search-form" role="search">
-          <input
+          <input 
             type="search"
             id="search-input"
             placeholder="Search..."
@@ -69,7 +69,7 @@
           Features experimentais ativas &nbsp;·&nbsp;
           <button onclick="toggleLabz()" style="background:none;border:none;cursor:pointer;color:inherit;font:inherit;text-decoration:underline;padding:0;">sair do modo Labz</button>
         </div>
-
+        
 
 <!-- reading-progress-hook removed FF-016: #reading-progress now in base.html -->
 
@@ -96,18 +96,18 @@
             🇧🇷 Português
         </label>
     </div>
-
+    
     <h1 class="title-en">The Pale Blue Dot……..</h1>
-
+    
     <h1 class="title-pt">O Pálido Ponto Azul……..</h1>
-
+    
 
     <!-- [SPRINT I] MOVIDO DE: Transmission Map foi recortado daqui para o final do post.html -->
 
 </header>
 
 <div class="post-container">
-
+    
     <!-- Breadcrumb desduplicado removido (Mantido context-pill acima do H1) -->
 
     <!-- [SPRINT L] BUG 1+2: meta-toggle-wrap FORA de content-en/pt — visível em ambos os idiomas -->
@@ -135,14 +135,14 @@
         <div class="mini-toc" id="toc-content-en" style="display: none; cursor: default; margin-top: 1rem;"><p><strong>Sections:</strong></p><ul id="toc-list-en"></ul></div>
     </div>
 
-
+    
     <div class="toc-pt" style="margin-bottom: 2rem; font-size: 0.95rem;">
         <button class="toc-reveal-btn" onclick="toggleTOC('toc-content-pt')">
             ☰ Ver seções deste texto
         </button>
         <div class="mini-toc" id="toc-content-pt" style="display: none; cursor: default; margin-top: 1rem;"><p><strong>Seções:</strong></p><ul id="toc-list-pt"></ul></div>
     </div>
-
+    
 
     <article class="content-block content-en" id="content-en"
              data-pdpn="TL.BB.002"
@@ -181,7 +181,7 @@
 <p>Next, "<a href="../../pages/TL.BB.003/index.html" rel="noopener noreferrer" target="_blank">The Law of Attraction, Habits, Character (Gati), and Cravings (Āsavas)</a>", ...........</p>
     </article>
 
-
+    
     <article class="content-block content-pt" id="content-pt"
              data-pdpn="TL.BB.002"
              data-section="Three Levels of Practice"
@@ -229,14 +229,14 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 </ul>
 <p>A seguir, “<a href="../../pages/TL.BB.003/index.html" target="_blank">A Lei da Atração, Hábitos, Caráter (Gati) e Desejos (Āsavas)</a>”, ...........</p>
     </article>
+    
 
-
-
-
-
-
-
-
+    
+    
+    
+    
+    
+    
     <section class="derived-media-companion derived-media-preparation-notice derived-media-language-en"
              aria-labelledby="derived-media-notice-title-TL.BB.002"
              data-source-pdpn="TL.BB.002"
@@ -245,81 +245,97 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
         <h2 id="derived-media-notice-title-TL.BB.002" class="derived-media-kicker">Auxiliary derived media</h2>
         <p class="derived-media-note">Auxiliary audio/video in English is being prepared. The Portuguese companion is available under the Português tab. For study and verification, use the original PureDhamma.net essay.</p>
     </section>
-
+    
     <section class="derived-media-companion derived-media-language-pt"
              aria-labelledby="derived-media-title-TL.BB.002"
              data-source-pdpn="TL.BB.002"
              data-review-status="approved"
              data-companion-language="pt-BR">
         <h2 id="derived-media-title-TL.BB.002" class="derived-media-kicker">Material auxiliar</h2>
-        <p class="derived-media-note">Este áudio e vídeo são materiais auxiliares de estudo preparados com apoio do NotebookLM a partir do ensaio original do PureDhamma.net. Eles não substituem o texto original em inglês, que continua sendo a referência principal para estudo e verificação. Atenção: o NotebookLM pode cometer erros de pronúncia ou reconhecimento de termos em Pāli e Sinhala/Cingalês, inclusive confundindo palavras com formas em Sânscrito.</p>
-
-
-
-
-        <div class="derived-media-audio">
-            <p>Áudio auxiliar</p>
-            <audio controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.002/pt-BR/audio.m4a"></audio>
+        <div class="derived-media-copy">
+            <p class="derived-media-note">Este áudio e vídeo são materiais auxiliares de estudo preparados com apoio do NotebookLM a partir do ensaio original do PureDhamma.net.</p>
+            
+            <p class="derived-media-reference">Eles não substituem o texto original em inglês, que continua sendo a referência principal para estudo e verificação.</p>
+            
+            
+            <p class="derived-media-warning">Atenção: o NotebookLM pode cometer erros de pronúncia ou reconhecimento de termos em Pāli e Sinhala/Cingalês, inclusive confundindo palavras com formas em Sânscrito.</p>
+            
         </div>
 
+        
 
+        
+        <div class="derived-media-player-group">
+            
+            <div class="derived-media-audio">
+                <p id="derived-media-audio-label-TL.BB.002" class="derived-media-player-label">Áudio do ensaio</p>
+                <div class="derived-media-player-shell">
+                    <audio controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.002/pt-BR/audio.m4a" aria-labelledby="derived-media-audio-label-TL.BB.002"></audio>
+                </div>
+            </div>
+            
 
-        <div class="derived-media-video">
-            <p>Vídeo auxiliar</p>
-            <video controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.002/pt-BR/video.mp4"></video>
+            
+            <div class="derived-media-video">
+                <p id="derived-media-video-label-TL.BB.002" class="derived-media-player-label">Vídeo do ensaio</p>
+                <div class="derived-media-player-shell">
+                    <video controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.002/pt-BR/video.mp4" aria-labelledby="derived-media-video-label-TL.BB.002"></video>
+                </div>
+            </div>
+            
         </div>
+        
 
-
-
+        
     </section>
-
+    
 
     <!-- SPRINT 3: Digestibility Suggestion -->
-
+    
 
     <!-- SPRINT 5: Silent Pause Block -->
-
+    
 
 </div>
 
 <!-- [SPRINT I] MOVIDO PARA: Transmission Map -->
 <hr class="nav-divider">
 <div class="transmission-map">
-
+    
     <div class="map-item">
         <span class="map-label">From:</span>
         <a href="../../pages/TL.BB.001/index.html">The Basics</a>
     </div>
-
-
-
+    
+    
+    
     <div class="map-item">
         <span class="map-label">To:</span>
         <a href="../../pages/TL.BB.003/index.html">Law Of Attraction Habits Gathi And Cravings Asavas</a>
     </div>
-
+    
 </div>
 
 <nav class="pathways" aria-label="Next and Previous">
-
+    
     <a class="pathway-link prev" href="../../pages/TL.BB.001/index.html">
         <span class="pathway-label">← Previous</span>
         <span class="pathway-title title-en">The Basics</span>
-
+        
         <span class="pathway-title title-pt">O básico</span>
-
+        
     </a>
+    
 
-
-
+    
     <a class="pathway-link next" href="../../pages/TL.BB.003/index.html">
         <span class="pathway-label">Next →</span>
         <span class="pathway-title title-en">Law Of Attraction Habits Gathi And Cravings Asavas</span>
-
+        
         <span class="pathway-title title-pt">Lei da Atração Hábitos Gathi e Desejos Āsavā</span>
-
+        
     </a>
-
+    
 </nav>
 
 <div id="ai-assistant-hook"></div>
@@ -331,7 +347,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 </nav>
 
 
-
+        
         <footer>
             <p>Dhamma Preservation Project. 2500 Years of Teaching.</p>
             <p><small>Generated Static Site. IPFS Compatible. <a href="../../index.html" style="color:inherit;text-decoration:underline;">Showcase Manual</a></small></p>
@@ -373,13 +389,13 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
         });
       }
     </script>
-
+    
     <!-- PRINT FORMAT MODAL UI -->
     <div id="print-modal-overlay" onclick="closePrintModal()"></div>
     <div id="print-modal" role="dialog" aria-labelledby="print-title">
         <h3 id="print-title">🖨️ Modo Impressão / PDF</h3>
         <p style="font-size: 0.85rem; color: var(--meta-color); margin-bottom: 1.5rem;">Configure as margens para anotações e economize folhas. Apenas a versão lida (Português) será impressa.</p>
-
+        
         <div class="print-group">
             <label for="p-margin">Tamanho da Margem Esquerda / Direita</label>
             <select id="p-margin">
@@ -388,7 +404,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
                 <option value="wide">Margem Larga (Para anotações a caneta)</option>
             </select>
         </div>
-
+        
         <div class="print-group">
             <label for="p-line">Espaçamento entre as Linhas</label>
             <select id="p-line">
@@ -405,7 +421,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
                 <option value="color">Manter Cores (Revisão e destaques)</option>
             </select>
         </div>
-
+        
         <div class="print-actions">
             <button class="print-btn" onclick="closePrintModal()">Cancelar</button>
             <button class="print-btn primary" onclick="executePrint()">Confirmar e Imprimir</button>

--- a/pipeline/13-static-site/pages/TL.BB.003/index.html
+++ b/pipeline/13-static-site/pages/TL.BB.003/index.html
@@ -53,7 +53,7 @@
     <main>
         <!-- Search UI (Sprint 9) -->
         <form id="search-form" role="search">
-          <input
+          <input 
             type="search"
             id="search-input"
             placeholder="Search..."
@@ -69,7 +69,7 @@
           Features experimentais ativas &nbsp;·&nbsp;
           <button onclick="toggleLabz()" style="background:none;border:none;cursor:pointer;color:inherit;font:inherit;text-decoration:underline;padding:0;">sair do modo Labz</button>
         </div>
-
+        
 
 <!-- reading-progress-hook removed FF-016: #reading-progress now in base.html -->
 
@@ -96,18 +96,18 @@
             🇧🇷 Português
         </label>
     </div>
-
+    
     <h1 class="title-en">Law Of Attraction Habits Gathi And Cravings Asavas</h1>
-
+    
     <h1 class="title-pt">Lei da Atração Hábitos Gathi e Desejos Āsavā</h1>
-
+    
 
     <!-- [SPRINT I] MOVIDO DE: Transmission Map foi recortado daqui para o final do post.html -->
 
 </header>
 
 <div class="post-container">
-
+    
     <!-- Breadcrumb desduplicado removido (Mantido context-pill acima do H1) -->
 
     <!-- [SPRINT L] BUG 1+2: meta-toggle-wrap FORA de content-en/pt — visível em ambos os idiomas -->
@@ -135,14 +135,14 @@
         <div class="mini-toc" id="toc-content-en" style="display: none; cursor: default; margin-top: 1rem;"><p><strong>Sections:</strong></p><ul id="toc-list-en"></ul></div>
     </div>
 
-
+    
     <div class="toc-pt" style="margin-bottom: 2rem; font-size: 0.95rem;">
         <button class="toc-reveal-btn" onclick="toggleTOC('toc-content-pt')">
             ☰ Ver seções deste texto
         </button>
         <div class="mini-toc" id="toc-content-pt" style="display: none; cursor: default; margin-top: 1rem;"><p><strong>Seções:</strong></p><ul id="toc-list-pt"></ul></div>
     </div>
-
+    
 
     <article class="content-block content-en" id="content-en"
              data-pdpn="TL.BB.003"
@@ -225,7 +225,7 @@
 <p style="text-align: justify">Next, "<a href="../../pages/TL.BB.004/index.html" rel="noopener noreferrer" target="_blank">Habits, Goals, and Character (Gati)</a>", ...</p>
     </article>
 
-
+    
     <article class="content-block content-pt" id="content-pt"
              data-pdpn="TL.BB.003"
              data-section="Three Levels of Practice"
@@ -317,14 +317,14 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 <p style="text-align: justify"><span>11. Existem vários livros disponíveis sobre a lei da atração e como se pode usar certos procedimentos para atingir objetivos, construir relacionamentos, etc. O <span class="pali-term term-highlight" data-term="buddha">Buddha</span> descreveu isso e muito mais há 2500 anos.</span></p>
 <p style="text-align: justify">A seguir, “<a href="../../pages/TL.BB.004/index.html">Hábitos, Objetivos e Caráter (Gati)</a>”, ...</p>
     </article>
+    
 
-
-
-
-
-
-
-
+    
+    
+    
+    
+    
+    
     <section class="derived-media-companion derived-media-preparation-notice derived-media-language-en"
              aria-labelledby="derived-media-notice-title-TL.BB.003"
              data-source-pdpn="TL.BB.003"
@@ -333,81 +333,97 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
         <h2 id="derived-media-notice-title-TL.BB.003" class="derived-media-kicker">Auxiliary derived media</h2>
         <p class="derived-media-note">Auxiliary audio/video in English is being prepared. The Portuguese companion is available under the Português tab. For study and verification, use the original PureDhamma.net essay.</p>
     </section>
-
+    
     <section class="derived-media-companion derived-media-language-pt"
              aria-labelledby="derived-media-title-TL.BB.003"
              data-source-pdpn="TL.BB.003"
              data-review-status="approved"
              data-companion-language="pt-BR">
         <h2 id="derived-media-title-TL.BB.003" class="derived-media-kicker">Material auxiliar</h2>
-        <p class="derived-media-note">Este áudio e vídeo são materiais auxiliares de estudo preparados com apoio do NotebookLM a partir do ensaio original do PureDhamma.net. Eles não substituem o texto original em inglês, que continua sendo a referência principal para estudo e verificação. Atenção: o NotebookLM pode cometer erros de pronúncia ou reconhecimento de termos em Pāli e Sinhala/Cingalês, inclusive confundindo palavras com formas em Sânscrito.</p>
-
-
-
-
-        <div class="derived-media-audio">
-            <p>Áudio auxiliar</p>
-            <audio controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.003/pt-BR/audio.m4a"></audio>
+        <div class="derived-media-copy">
+            <p class="derived-media-note">Este áudio e vídeo são materiais auxiliares de estudo preparados com apoio do NotebookLM a partir do ensaio original do PureDhamma.net.</p>
+            
+            <p class="derived-media-reference">Eles não substituem o texto original em inglês, que continua sendo a referência principal para estudo e verificação.</p>
+            
+            
+            <p class="derived-media-warning">Atenção: o NotebookLM pode cometer erros de pronúncia ou reconhecimento de termos em Pāli e Sinhala/Cingalês, inclusive confundindo palavras com formas em Sânscrito.</p>
+            
         </div>
 
+        
 
+        
+        <div class="derived-media-player-group">
+            
+            <div class="derived-media-audio">
+                <p id="derived-media-audio-label-TL.BB.003" class="derived-media-player-label">Áudio do ensaio</p>
+                <div class="derived-media-player-shell">
+                    <audio controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.003/pt-BR/audio.m4a" aria-labelledby="derived-media-audio-label-TL.BB.003"></audio>
+                </div>
+            </div>
+            
 
-        <div class="derived-media-video">
-            <p>Vídeo auxiliar</p>
-            <video controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.003/pt-BR/video.mp4"></video>
+            
+            <div class="derived-media-video">
+                <p id="derived-media-video-label-TL.BB.003" class="derived-media-player-label">Vídeo do ensaio</p>
+                <div class="derived-media-player-shell">
+                    <video controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.003/pt-BR/video.mp4" aria-labelledby="derived-media-video-label-TL.BB.003"></video>
+                </div>
+            </div>
+            
         </div>
+        
 
-
-
+        
     </section>
-
+    
 
     <!-- SPRINT 3: Digestibility Suggestion -->
-
+    
 
     <!-- SPRINT 5: Silent Pause Block -->
-
+    
 
 </div>
 
 <!-- [SPRINT I] MOVIDO PARA: Transmission Map -->
 <hr class="nav-divider">
 <div class="transmission-map">
-
+    
     <div class="map-item">
         <span class="map-label">From:</span>
         <a href="../../pages/TL.BB.002/index.html">The Pale Blue Dot……..</a>
     </div>
-
-
-
+    
+    
+    
     <div class="map-item">
         <span class="map-label">To:</span>
         <a href="../../pages/TL.BB.004/index.html">How To Remove Bad Habits</a>
     </div>
-
+    
 </div>
 
 <nav class="pathways" aria-label="Next and Previous">
-
+    
     <a class="pathway-link prev" href="../../pages/TL.BB.002/index.html">
         <span class="pathway-label">← Previous</span>
         <span class="pathway-title title-en">The Pale Blue Dot……..</span>
-
+        
         <span class="pathway-title title-pt">O Pálido Ponto Azul……..</span>
-
+        
     </a>
+    
 
-
-
+    
     <a class="pathway-link next" href="../../pages/TL.BB.004/index.html">
         <span class="pathway-label">Next →</span>
         <span class="pathway-title title-en">How To Remove Bad Habits</span>
-
+        
         <span class="pathway-title title-pt">Como remover maus hábitos</span>
-
+        
     </a>
-
+    
 </nav>
 
 <div id="ai-assistant-hook"></div>
@@ -419,7 +435,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 </nav>
 
 
-
+        
         <footer>
             <p>Dhamma Preservation Project. 2500 Years of Teaching.</p>
             <p><small>Generated Static Site. IPFS Compatible. <a href="../../index.html" style="color:inherit;text-decoration:underline;">Showcase Manual</a></small></p>
@@ -461,13 +477,13 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
         });
       }
     </script>
-
+    
     <!-- PRINT FORMAT MODAL UI -->
     <div id="print-modal-overlay" onclick="closePrintModal()"></div>
     <div id="print-modal" role="dialog" aria-labelledby="print-title">
         <h3 id="print-title">🖨️ Modo Impressão / PDF</h3>
         <p style="font-size: 0.85rem; color: var(--meta-color); margin-bottom: 1.5rem;">Configure as margens para anotações e economize folhas. Apenas a versão lida (Português) será impressa.</p>
-
+        
         <div class="print-group">
             <label for="p-margin">Tamanho da Margem Esquerda / Direita</label>
             <select id="p-margin">
@@ -476,7 +492,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
                 <option value="wide">Margem Larga (Para anotações a caneta)</option>
             </select>
         </div>
-
+        
         <div class="print-group">
             <label for="p-line">Espaçamento entre as Linhas</label>
             <select id="p-line">
@@ -493,7 +509,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
                 <option value="color">Manter Cores (Revisão e destaques)</option>
             </select>
         </div>
-
+        
         <div class="print-actions">
             <button class="print-btn" onclick="closePrintModal()">Cancelar</button>
             <button class="print-btn primary" onclick="executePrint()">Confirmar e Imprimir</button>

--- a/pipeline/13-static-site/pages/TL.BB.006/index.html
+++ b/pipeline/13-static-site/pages/TL.BB.006/index.html
@@ -53,7 +53,7 @@
     <main>
         <!-- Search UI (Sprint 9) -->
         <form id="search-form" role="search">
-          <input
+          <input 
             type="search"
             id="search-input"
             placeholder="Search..."
@@ -69,7 +69,7 @@
           Features experimentais ativas &nbsp;·&nbsp;
           <button onclick="toggleLabz()" style="background:none;border:none;cursor:pointer;color:inherit;font:inherit;text-decoration:underline;padding:0;">sair do modo Labz</button>
         </div>
-
+        
 
 <!-- reading-progress-hook removed FF-016: #reading-progress now in base.html -->
 
@@ -96,18 +96,18 @@
             🇧🇷 Português
         </label>
     </div>
-
+    
     <h1 class="title-en">Four Noble Truths Recipe For Problem Solving</h1>
-
+    
     <h1 class="title-pt">Quatro Nobres Verdades Receita para a solução de problemas</h1>
-
+    
 
     <!-- [SPRINT I] MOVIDO DE: Transmission Map foi recortado daqui para o final do post.html -->
 
 </header>
 
 <div class="post-container">
-
+    
     <!-- Breadcrumb desduplicado removido (Mantido context-pill acima do H1) -->
 
     <!-- [SPRINT L] BUG 1+2: meta-toggle-wrap FORA de content-en/pt — visível em ambos os idiomas -->
@@ -135,14 +135,14 @@
         <div class="mini-toc" id="toc-content-en" style="display: none; cursor: default; margin-top: 1rem;"><p><strong>Sections:</strong></p><ul id="toc-list-en"></ul></div>
     </div>
 
-
+    
     <div class="toc-pt" style="margin-bottom: 2rem; font-size: 0.95rem;">
         <button class="toc-reveal-btn" onclick="toggleTOC('toc-content-pt')">
             ☰ Ver seções deste texto
         </button>
         <div class="mini-toc" id="toc-content-pt" style="display: none; cursor: default; margin-top: 1rem;"><p><strong>Seções:</strong></p><ul id="toc-list-pt"></ul></div>
     </div>
-
+    
 
     <article class="content-block content-en" id="content-en"
              data-pdpn="TL.BB.006"
@@ -274,7 +274,7 @@
 </ul>
     </article>
 
-
+    
     <article class="content-block content-pt" id="content-pt"
              data-pdpn="TL.BB.006"
              data-section="Three Levels of Practice"
@@ -415,14 +415,14 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 <li style="text-align: justify">Então, segue-se o Nobre Caminho Óctuplo transcendental (<em>lokottara</em>) para atingir <em><span>o <span class="pali-term term-highlight" data-term="nibbāna">Nibbāna</span></span></em>, purificando completamente a mente de todas as seis raízes. É um processo passo a passo. Veja “<a href="../../pages/LD.EE.002/index.html">É necessário que um Buddhista elimine os desejos sensuais?</a>”.</li>
 </ul>
     </article>
+    
 
-
-
-
-
-
-
-
+    
+    
+    
+    
+    
+    
     <section class="derived-media-companion derived-media-preparation-notice derived-media-language-en"
              aria-labelledby="derived-media-notice-title-TL.BB.006"
              data-source-pdpn="TL.BB.006"
@@ -431,81 +431,97 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
         <h2 id="derived-media-notice-title-TL.BB.006" class="derived-media-kicker">Auxiliary derived media</h2>
         <p class="derived-media-note">Auxiliary audio/video in English is being prepared. The Portuguese companion is available under the Português tab. For study and verification, use the original PureDhamma.net essay.</p>
     </section>
-
+    
     <section class="derived-media-companion derived-media-language-pt"
              aria-labelledby="derived-media-title-TL.BB.006"
              data-source-pdpn="TL.BB.006"
              data-review-status="approved"
              data-companion-language="pt-BR">
         <h2 id="derived-media-title-TL.BB.006" class="derived-media-kicker">Material auxiliar</h2>
-        <p class="derived-media-note">Este áudio e vídeo são materiais auxiliares de estudo preparados com apoio do NotebookLM a partir do ensaio original do PureDhamma.net. Eles não substituem o texto original em inglês, que continua sendo a referência principal para estudo e verificação. Atenção: o NotebookLM pode cometer erros de pronúncia ou reconhecimento de termos em Pāli e Sinhala/Cingalês, inclusive confundindo palavras com formas em Sânscrito.</p>
-
-
-
-
-        <div class="derived-media-audio">
-            <p>Áudio auxiliar</p>
-            <audio controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.006/pt-BR/audio.m4a"></audio>
+        <div class="derived-media-copy">
+            <p class="derived-media-note">Este áudio e vídeo são materiais auxiliares de estudo preparados com apoio do NotebookLM a partir do ensaio original do PureDhamma.net.</p>
+            
+            <p class="derived-media-reference">Eles não substituem o texto original em inglês, que continua sendo a referência principal para estudo e verificação.</p>
+            
+            
+            <p class="derived-media-warning">Atenção: o NotebookLM pode cometer erros de pronúncia ou reconhecimento de termos em Pāli e Sinhala/Cingalês, inclusive confundindo palavras com formas em Sânscrito.</p>
+            
         </div>
 
+        
 
+        
+        <div class="derived-media-player-group">
+            
+            <div class="derived-media-audio">
+                <p id="derived-media-audio-label-TL.BB.006" class="derived-media-player-label">Áudio do ensaio</p>
+                <div class="derived-media-player-shell">
+                    <audio controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.006/pt-BR/audio.m4a" aria-labelledby="derived-media-audio-label-TL.BB.006"></audio>
+                </div>
+            </div>
+            
 
-        <div class="derived-media-video">
-            <p>Vídeo auxiliar</p>
-            <video controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.006/pt-BR/video.mp4"></video>
+            
+            <div class="derived-media-video">
+                <p id="derived-media-video-label-TL.BB.006" class="derived-media-player-label">Vídeo do ensaio</p>
+                <div class="derived-media-player-shell">
+                    <video controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.BB.006/pt-BR/video.mp4" aria-labelledby="derived-media-video-label-TL.BB.006"></video>
+                </div>
+            </div>
+            
         </div>
+        
 
-
-
+        
     </section>
-
+    
 
     <!-- SPRINT 3: Digestibility Suggestion -->
-
+    
 
     <!-- SPRINT 5: Silent Pause Block -->
-
+    
 
 </div>
 
 <!-- [SPRINT I] MOVIDO PARA: Transmission Map -->
 <hr class="nav-divider">
 <div class="transmission-map">
-
+    
     <div class="map-item">
         <span class="map-label">From:</span>
         <a href="../../pages/TL.BB.005/index.html">Miccha Ditthi Simpler Analysis</a>
     </div>
-
-
-
+    
+    
+    
     <div class="map-item">
         <span class="map-label">To:</span>
         <a href="../../pages/TL.BB.007/index.html">First Noble Truth A Simple Explanation Of One Aspect</a>
     </div>
-
+    
 </div>
 
 <nav class="pathways" aria-label="Next and Previous">
-
+    
     <a class="pathway-link prev" href="../../pages/TL.BB.005/index.html">
         <span class="pathway-label">← Previous</span>
         <span class="pathway-title title-en">Miccha Ditthi Simpler Analysis</span>
-
+        
         <span class="pathway-title title-pt">Análise mais simples de Diṭṭhi</span>
-
+        
     </a>
+    
 
-
-
+    
     <a class="pathway-link next" href="../../pages/TL.BB.007/index.html">
         <span class="pathway-label">Next →</span>
         <span class="pathway-title title-en">First Noble Truth A Simple Explanation Of One Aspect</span>
-
+        
         <span class="pathway-title title-pt">Primeira Nobre Verdade Uma Explicação Simples de um Aspecto</span>
-
+        
     </a>
-
+    
 </nav>
 
 <div id="ai-assistant-hook"></div>
@@ -517,7 +533,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 </nav>
 
 
-
+        
         <footer>
             <p>Dhamma Preservation Project. 2500 Years of Teaching.</p>
             <p><small>Generated Static Site. IPFS Compatible. <a href="../../index.html" style="color:inherit;text-decoration:underline;">Showcase Manual</a></small></p>
@@ -559,13 +575,13 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
         });
       }
     </script>
-
+    
     <!-- PRINT FORMAT MODAL UI -->
     <div id="print-modal-overlay" onclick="closePrintModal()"></div>
     <div id="print-modal" role="dialog" aria-labelledby="print-title">
         <h3 id="print-title">🖨️ Modo Impressão / PDF</h3>
         <p style="font-size: 0.85rem; color: var(--meta-color); margin-bottom: 1.5rem;">Configure as margens para anotações e economize folhas. Apenas a versão lida (Português) será impressa.</p>
-
+        
         <div class="print-group">
             <label for="p-margin">Tamanho da Margem Esquerda / Direita</label>
             <select id="p-margin">
@@ -574,7 +590,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
                 <option value="wide">Margem Larga (Para anotações a caneta)</option>
             </select>
         </div>
-
+        
         <div class="print-group">
             <label for="p-line">Espaçamento entre as Linhas</label>
             <select id="p-line">
@@ -591,7 +607,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
                 <option value="color">Manter Cores (Revisão e destaques)</option>
             </select>
         </div>
-
+        
         <div class="print-actions">
             <button class="print-btn" onclick="closePrintModal()">Cancelar</button>
             <button class="print-btn primary" onclick="executePrint()">Confirmar e Imprimir</button>

--- a/pipeline/13-static-site/pages/TL.CC.003/index.html
+++ b/pipeline/13-static-site/pages/TL.CC.003/index.html
@@ -53,7 +53,7 @@
     <main>
         <!-- Search UI (Sprint 9) -->
         <form id="search-form" role="search">
-          <input
+          <input 
             type="search"
             id="search-input"
             placeholder="Search..."
@@ -69,7 +69,7 @@
           Features experimentais ativas &nbsp;·&nbsp;
           <button onclick="toggleLabz()" style="background:none;border:none;cursor:pointer;color:inherit;font:inherit;text-decoration:underline;padding:0;">sair do modo Labz</button>
         </div>
-
+        
 
 <!-- reading-progress-hook removed FF-016: #reading-progress now in base.html -->
 
@@ -96,18 +96,18 @@
             🇧🇷 Português
         </label>
     </div>
-
+    
     <h1 class="title-en">Solution To A Wandering Mind Abandon Everything</h1>
-
+    
     <h1 class="title-pt">Solução para uma mente errante Abandonar tudo</h1>
-
+    
 
     <!-- [SPRINT I] MOVIDO DE: Transmission Map foi recortado daqui para o final do post.html -->
 
 </header>
 
 <div class="post-container">
-
+    
     <!-- Breadcrumb desduplicado removido (Mantido context-pill acima do H1) -->
 
     <!-- [SPRINT L] BUG 1+2: meta-toggle-wrap FORA de content-en/pt — visível em ambos os idiomas -->
@@ -135,14 +135,14 @@
         <div class="mini-toc" id="toc-content-en" style="display: none; cursor: default; margin-top: 1rem;"><p><strong>Sections:</strong></p><ul id="toc-list-en"></ul></div>
     </div>
 
-
+    
     <div class="toc-pt" style="margin-bottom: 2rem; font-size: 0.95rem;">
         <button class="toc-reveal-btn" onclick="toggleTOC('toc-content-pt')">
             ☰ Ver seções deste texto
         </button>
         <div class="mini-toc" id="toc-content-pt" style="display: none; cursor: default; margin-top: 1rem;"><p><strong>Seções:</strong></p><ul id="toc-list-pt"></ul></div>
     </div>
-
+    
 
     <article class="content-block content-en" id="content-en"
              data-pdpn="TL.CC.003"
@@ -196,7 +196,7 @@
 <p style="text-align: justify;">Next, "<a href="../../pages/TL.CC.004/index.html" rel="noopener noreferrer" target="_blank">Right Speech – How to Avoid Accumulating Kamma</a>",.</p>
     </article>
 
-
+    
     <article class="content-block content-pt" id="content-pt"
              data-pdpn="TL.CC.003"
              data-section="Three Levels of Practice"
@@ -259,14 +259,14 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 <p style="text-align: justify;"><strong>Portanto, trata-se de limpar as impurezas (maus hábitos) INTERIORES, ou seja, na mente; veja “<a href="../../pages/BM.AA.001/index.html" title="Introduction to Buddhist Meditation">Introdução à Meditação Buddhista</a>”. Uma vez feito isso para todas as impurezas, nenhuma influência externa pode afetar a compostura (veja o nº 10 acima). É possível até mesmo atingir esse estágio final enquanto se permanece no mundo real. </strong></p>
 <p style="text-align: justify;">A seguir, “<a href="../../pages/TL.CC.004/index.html">Fala correta – Como evitar acumular Kamma</a>”.</p>
     </article>
+    
 
-
-
-
-
-
-
-
+    
+    
+    
+    
+    
+    
     <section class="derived-media-companion derived-media-preparation-notice derived-media-language-en"
              aria-labelledby="derived-media-notice-title-TL.CC.003"
              data-source-pdpn="TL.CC.003"
@@ -275,81 +275,97 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
         <h2 id="derived-media-notice-title-TL.CC.003" class="derived-media-kicker">Auxiliary derived media</h2>
         <p class="derived-media-note">Auxiliary audio/video in English is being prepared. The Portuguese companion is available under the Português tab. For study and verification, use the original PureDhamma.net essay.</p>
     </section>
-
+    
     <section class="derived-media-companion derived-media-language-pt"
              aria-labelledby="derived-media-title-TL.CC.003"
              data-source-pdpn="TL.CC.003"
              data-review-status="approved"
              data-companion-language="pt-BR">
         <h2 id="derived-media-title-TL.CC.003" class="derived-media-kicker">Material auxiliar</h2>
-        <p class="derived-media-note">Este áudio e vídeo são materiais auxiliares de estudo preparados com apoio do NotebookLM a partir do ensaio original do PureDhamma.net. Eles não substituem o texto original em inglês, que continua sendo a referência principal para estudo e verificação. Atenção: o NotebookLM pode cometer erros de pronúncia ou reconhecimento de termos em Pāli e Sinhala/Cingalês, inclusive confundindo palavras com formas em Sânscrito.</p>
-
-
-
-
-        <div class="derived-media-audio">
-            <p>Áudio auxiliar</p>
-            <audio controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.CC.003/pt-BR/audio.m4a"></audio>
+        <div class="derived-media-copy">
+            <p class="derived-media-note">Este áudio e vídeo são materiais auxiliares de estudo preparados com apoio do NotebookLM a partir do ensaio original do PureDhamma.net.</p>
+            
+            <p class="derived-media-reference">Eles não substituem o texto original em inglês, que continua sendo a referência principal para estudo e verificação.</p>
+            
+            
+            <p class="derived-media-warning">Atenção: o NotebookLM pode cometer erros de pronúncia ou reconhecimento de termos em Pāli e Sinhala/Cingalês, inclusive confundindo palavras com formas em Sânscrito.</p>
+            
         </div>
 
+        
 
+        
+        <div class="derived-media-player-group">
+            
+            <div class="derived-media-audio">
+                <p id="derived-media-audio-label-TL.CC.003" class="derived-media-player-label">Áudio do ensaio</p>
+                <div class="derived-media-player-shell">
+                    <audio controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.CC.003/pt-BR/audio.m4a" aria-labelledby="derived-media-audio-label-TL.CC.003"></audio>
+                </div>
+            </div>
+            
 
-        <div class="derived-media-video">
-            <p>Vídeo auxiliar</p>
-            <video controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.CC.003/pt-BR/video.mp4"></video>
+            
+            <div class="derived-media-video">
+                <p id="derived-media-video-label-TL.CC.003" class="derived-media-player-label">Vídeo do ensaio</p>
+                <div class="derived-media-player-shell">
+                    <video controls preload="metadata" src="https://pub-bd56cac1d526432981a10bed4c410f9c.r2.dev/derived-media/TL.CC.003/pt-BR/video.mp4" aria-labelledby="derived-media-video-label-TL.CC.003"></video>
+                </div>
+            </div>
+            
         </div>
+        
 
-
-
+        
     </section>
-
+    
 
     <!-- SPRINT 3: Digestibility Suggestion -->
-
+    
 
     <!-- SPRINT 5: Silent Pause Block -->
-
+    
 
 </div>
 
 <!-- [SPRINT I] MOVIDO PARA: Transmission Map -->
 <hr class="nav-divider">
 <div class="transmission-map">
-
+    
     <div class="map-item">
         <span class="map-label">From:</span>
         <a href="../../pages/TL.CC.002/index.html">Key To Calming The Mind Five Hindrances</a>
     </div>
-
-
-
+    
+    
+    
     <div class="map-item">
         <span class="map-label">To:</span>
         <a href="../../pages/TL.CC.004/index.html">Right Speech</a>
     </div>
-
+    
 </div>
 
 <nav class="pathways" aria-label="Next and Previous">
-
+    
     <a class="pathway-link prev" href="../../pages/TL.CC.002/index.html">
         <span class="pathway-label">← Previous</span>
         <span class="pathway-title title-en">Key To Calming The Mind Five Hindrances</span>
-
+        
         <span class="pathway-title title-pt">Chave para acalmar a mente Cinco Estorvos</span>
-
+        
     </a>
+    
 
-
-
+    
     <a class="pathway-link next" href="../../pages/TL.CC.004/index.html">
         <span class="pathway-label">Next →</span>
         <span class="pathway-title title-en">Right Speech</span>
-
+        
         <span class="pathway-title title-pt">Discurso correto</span>
-
+        
     </a>
-
+    
 </nav>
 
 <div id="ai-assistant-hook"></div>
@@ -361,7 +377,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
 </nav>
 
 
-
+        
         <footer>
             <p>Dhamma Preservation Project. 2500 Years of Teaching.</p>
             <p><small>Generated Static Site. IPFS Compatible. <a href="../../index.html" style="color:inherit;text-decoration:underline;">Showcase Manual</a></small></p>
@@ -403,13 +419,13 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
         });
       }
     </script>
-
+    
     <!-- PRINT FORMAT MODAL UI -->
     <div id="print-modal-overlay" onclick="closePrintModal()"></div>
     <div id="print-modal" role="dialog" aria-labelledby="print-title">
         <h3 id="print-title">🖨️ Modo Impressão / PDF</h3>
         <p style="font-size: 0.85rem; color: var(--meta-color); margin-bottom: 1.5rem;">Configure as margens para anotações e economize folhas. Apenas a versão lida (Português) será impressa.</p>
-
+        
         <div class="print-group">
             <label for="p-margin">Tamanho da Margem Esquerda / Direita</label>
             <select id="p-margin">
@@ -418,7 +434,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
                 <option value="wide">Margem Larga (Para anotações a caneta)</option>
             </select>
         </div>
-
+        
         <div class="print-group">
             <label for="p-line">Espaçamento entre as Linhas</label>
             <select id="p-line">
@@ -435,7 +451,7 @@ DO NOT EDIT WITHOUT REVIEW LOG. THIS IS A DERIVATIVE WORK.
                 <option value="color">Manter Cores (Revisão e destaques)</option>
             </select>
         </div>
-
+        
         <div class="print-actions">
             <button class="print-btn" onclick="closePrintModal()">Cancelar</button>
             <button class="print-btn primary" onclick="executePrint()">Confirmar e Imprimir</button>


### PR DESCRIPTION
Summary:
Polishes the audio/video-only Derived Media Companion UI and improves the reader-facing disclaimer.

Closes #222

Scope:
- Clearer public disclaimer, split into three parts: auxiliary-material intro, reference-essay note, and a separate NotebookLM/Pāli/Sinhala/Sanskrit warning callout.
- Separates the auxiliary-material note from the warning visually (quiet bordered callout, not alarm-colored).
- Improves audio/video block spacing and styling: grouped in a `.derived-media-player-group`, each player in its own `.derived-media-player-shell` with a clear label ("Áudio do ensaio" / "Vídeo do ensaio") wired via `aria-labelledby`.
- Keeps language gating (CSS-only radio switcher, unchanged).
- Keeps R2 URLs (untouched — same `src` values).
- No summaries reintroduced.
- No binary media.
- No Netlify promotion.
- Does not mention "CSL" to readers anywhere in the copy.

Playback speed controls: **deferred**. Native `<audio>`/`<video>` controls differ too much across Chrome/Firefox/Safari for both element types to guarantee consistent behavior, and a reliable, accessible, dependency-free custom control spanning both would be more than a small polish-scope addition.

Safety:
- No CSL changes.
- No translation changes.
- No source ZIP changes.
- No registry/manifest changes.
- No .m4a/.mp4/.webm/.wav/.mp3 tracked.
- No Cloudflare settings changed.
- No manual deploy / no wrangler run.

Validation:
- `python3 -m py_compile` passed on `build.py` and `post_renderer.py`.
- Full static build run, then surgically restored so only the 4 target pages (`TL.BB.002`, `TL.BB.003`, `TL.BB.006`, `TL.CC.003`) + the CSS copy were kept — the full rebuild otherwise touches all 748 pages due to pre-existing unrelated drift between checked-in output and current CSL/translations state (flagged, not part of this PR).
- Confirmed new disclaimer structure, audio/video, and correct pt-BR/English gating render for all 4 target pages.
- Confirmed old "CSL continua sendo a fonte de verdade" / summary-control wording is absent.
- Confirmed neighbor pages (`TL.BB.005`, `TL.CC.002`) unaffected.
- Headless-Chromium screenshots taken for: pt-BR state (desktop + 375px mobile width, no overflow) and English preparation-notice state.
- No binary media, no Canon/registry/manifest files in the diff.

Rollback:
Revert this commit to restore the previous audio/video Companion UI.

Do NOT merge.
Do NOT mark ready unless operator asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)